### PR TITLE
Add sandbox property to analytics & Fix multiple event dispatchers issue

### DIFF
--- a/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsLogger.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsLogger.kt
@@ -20,7 +20,7 @@ package app.cash.paykit.analytics
 import android.util.Log
 
 class AnalyticsLogger(
-  private val options: AnalyticsOptions = AnalyticsOptions(),
+  private val options: AnalyticsOptions,
 ) {
   fun v(tag: String, msg: String) {
     if (options.logLevel <= Log.VERBOSE) {

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsOptions.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsOptions.kt
@@ -36,7 +36,7 @@ data class AnalyticsOptions constructor(
   val batchSize: Int = 10,
 
   /** The name of the database file on disk. */
-  val databaseName: String = "paykit-events.db",
+  val databaseName: String,
 
   /** The log level. */
   val logLevel: Int = Log.ERROR,

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
@@ -236,6 +236,19 @@ class PayKitAnalytics constructor(
     }
   }
 
+  @Synchronized
+  fun unregisterDeliveryHandler(handler: DeliveryHandler) {
+    deliveryHandlers.remove(handler)
+    logger.i(
+      TAG,
+      "Unregistering %s as delivery handler for %s".format(
+        Locale.US,
+        handler.javaClass.simpleName,
+        handler.deliverableType,
+      ),
+    )
+  }
+
   /**
    * Returns synchronization handler for given package type.
    *

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class PayKitAnalytics constructor(
   private val context: Context,
-  private val options: AnalyticsOptions = AnalyticsOptions(),
+  private val options: AnalyticsOptions,
   private val sqLiteHelper: AnalyticsSqLiteHelper = AnalyticsSqLiteHelper(
     context = context,
     options = options,

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
@@ -117,7 +117,7 @@ class PayKitAnalytics constructor(
    * .mPeriod and synchronization start will be delayed for number of seconds defined in Options.mDelay.
    */
   private fun initializeScheduledExecutorService() {
-    shouldShutdown.getAndSet(false)
+    shouldShutdown.set(false)
     scheduler = Executors.newSingleThreadScheduledExecutor().also {
       logger.d(
         TAG,
@@ -188,7 +188,7 @@ class PayKitAnalytics constructor(
   ) : FutureTask<Unit>(DeliveryWorker(dataSource, handlers, logger))
 
   fun scheduleShutdown() {
-    shouldShutdown.getAndSet(true)
+    shouldShutdown.set(true)
     logger.i(TAG, "Scheduled shutdown.")
   }
 
@@ -206,7 +206,7 @@ class PayKitAnalytics constructor(
       logger.i(TAG, "FutureTask list cleared.")
     }
 
-    // TODO shutdown the database?
+    sqLiteHelper.close()
     logger.i(TAG, "Shutdown completed.")
   }
 
@@ -234,19 +234,6 @@ class PayKitAnalytics constructor(
         ),
       )
     }
-  }
-
-  @Synchronized
-  fun unregisterDeliveryHandler(handler: DeliveryHandler) {
-    deliveryHandlers.remove(handler)
-    logger.i(
-      TAG,
-      "Unregistering %s as delivery handler for %s".format(
-        Locale.US,
-        handler.javaClass.simpleName,
-        handler.deliverableType,
-      ),
-    )
   }
 
   /**

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryWorker.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryWorker.kt
@@ -18,7 +18,6 @@
 package app.cash.paykit.analytics.core
 
 import app.cash.paykit.analytics.AnalyticsLogger
-import app.cash.paykit.analytics.AnalyticsOptions
 import app.cash.paykit.analytics.persistence.AnalyticEntry
 import app.cash.paykit.analytics.persistence.EntriesDataSource
 import app.cash.paykit.analytics.persistence.toCommaSeparatedListIds
@@ -28,7 +27,7 @@ import java.util.concurrent.Callable
 internal class DeliveryWorker(
   private val dataSource: EntriesDataSource,
   private val handlers: List<DeliveryHandler> = emptyList(),
-  private val logger: AnalyticsLogger = AnalyticsLogger(AnalyticsOptions()),
+  private val logger: AnalyticsLogger,
 ) : Callable<Unit> {
   init {
     logger.d(TAG, "DeliveryWorker initialized.")

--- a/analytics-core/src/test/java/app/cash/paykit/analytics/DeliveryWorkerTest.kt
+++ b/analytics-core/src/test/java/app/cash/paykit/analytics/DeliveryWorkerTest.kt
@@ -39,8 +39,9 @@ class DeliveryWorkerTest {
   @Test
   fun testNoDeliveryHandlers() {
     val dataSource: AnalyticsSQLiteDataSource = mockk(relaxed = true)
+    val analyticsOptions: AnalyticsOptions = mockk(relaxed = true)
     val handlers = ArrayList<DeliveryHandler>()
-    val worker = DeliveryWorker(dataSource, handlers, AnalyticsLogger())
+    val worker = DeliveryWorker(dataSource, handlers, AnalyticsLogger(analyticsOptions))
     worker.call()
 
     verify(inverse = true) { dataSource.generateProcessId(any()) }
@@ -62,7 +63,8 @@ class DeliveryWorkerTest {
     }
 
     val handlers = listOf(deliveryHandler)
-    val worker = DeliveryWorker(dataSource, handlers, AnalyticsLogger())
+    val analyticsLogger: AnalyticsLogger = mockk(relaxed = true)
+    val worker = DeliveryWorker(dataSource, handlers, analyticsLogger)
     worker.call()
 
     verify(exactly = 1) { dataSource.generateProcessId(eq(deliveryType)) }
@@ -124,7 +126,8 @@ class DeliveryWorkerTest {
       Utils.getEntriesToSync(0)
 
     // start processing
-    DeliveryWorker(dataSource, handlers, AnalyticsLogger()).call()
+    val analyticsLogger: AnalyticsLogger = mockk(relaxed = true)
+    DeliveryWorker(dataSource, handlers, analyticsLogger).call()
 
     // Processing 1st handler
     verifyOrder {

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
@@ -112,8 +112,6 @@ object CashAppPayKitFactory {
 
   private val payKitLifecycleObserver: PayKitLifecycleObserver = PayKitLifecycleObserverImpl()
 
-  private val paykitAnalytics by lazy { buildPayKitAnalytics() }
-
   private fun buildPayKitAnalytics() =
     with(ApplicationContextHolder.applicationContext) {
       val info = packageManager.getPackageInfo(packageName, 0)
@@ -152,8 +150,9 @@ object CashAppPayKitFactory {
       userAgentValue = getUserAgentValue(),
       okHttpClient = defaultOkHttpClient,
     )
+    val analytics = buildPayKitAnalytics()
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics, isSandbox = false)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, isSandbox = false)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppPayKitImpl(
@@ -178,8 +177,9 @@ object CashAppPayKitFactory {
       okHttpClient = defaultOkHttpClient,
     )
 
+    val analytics = buildPayKitAnalytics()
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics, isSandbox = true)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, isSandbox = true)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppPayKitImpl(

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
@@ -153,7 +153,7 @@ object CashAppPayKitFactory {
       okHttpClient = defaultOkHttpClient,
     )
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics, isSandbox = false)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppPayKitImpl(
@@ -179,7 +179,7 @@ object CashAppPayKitFactory {
     )
 
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics, isSandbox = true)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppPayKitImpl(
@@ -195,6 +195,7 @@ object CashAppPayKitFactory {
     clientId: String,
     networkManager: NetworkManager,
     eventsManager: PayKitAnalytics,
+    isSandbox: Boolean,
   ): PayKitAnalyticsEventDispatcher {
     val sdkVersion =
       ApplicationContextHolder.applicationContext.getString(R.string.cashpaykit_version)
@@ -202,6 +203,7 @@ object CashAppPayKitFactory {
       sdkVersion,
       clientId,
       getUserAgentValue(),
+      isSandbox,
       eventsManager,
       networkManager,
     )

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
@@ -54,4 +54,9 @@ internal interface PayKitAnalyticsEventDispatcher {
     payKitExceptionState: PayKitExceptionState,
     customerResponseData: CustomerResponseData?,
   )
+
+  /**
+   * Command this [PayKitAnalyticsEventDispatcher] to stop executing and discard.
+   */
+  fun shutdown()
 }

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -193,9 +193,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   }
 
   override fun shutdown() {
-    eventStreamDeliverHandler?.let {
-      payKitAnalytics.unregisterDeliveryHandler(it)
-    }
+    payKitAnalytics.scheduleShutdown()
   }
 
   private fun createOrUpdateAnalyticsPayload(

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -62,13 +62,16 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   private val sdkVersion: String,
   private val clientId: String,
   private val userAgent: String,
+  private val isSandbox: Boolean,
   private val payKitAnalytics: PayKitAnalytics,
   private val networkManager: NetworkManager,
   private val moshi: Moshi = Moshi.Builder().build(),
 ) : PayKitAnalyticsEventDispatcher {
 
+  private var eventStreamDeliverHandler: DeliveryHandler? = null
+
   init {
-    val eventStreamDeliverHandler = object : DeliveryHandler() {
+    eventStreamDeliverHandler = object : DeliveryHandler() {
 
       override val deliverableType = ESEventType
 
@@ -81,13 +84,15 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       }
     }
 
-    payKitAnalytics.registerDeliveryHandler(eventStreamDeliverHandler)
+    eventStreamDeliverHandler?.let {
+      payKitAnalytics.registerDeliveryHandler(it)
+    }
   }
 
   override fun sdkInitialized() {
     // Inner payload of the ES2 event.
     val initializationPayload =
-      AnalyticsInitializationPayload(sdkVersion, userAgent, PLATFORM, clientId)
+      AnalyticsInitializationPayload(sdkVersion, userAgent, PLATFORM, clientId, isSandbox)
 
     val es2EventAsJsonString =
       encodeToJsonString(initializationPayload, AnalyticsInitializationPayload.CATALOG)
@@ -99,7 +104,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun eventListenerAdded() {
     // Inner payload of the ES2 event.
     val eventPayload =
-      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = true)
+      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = true, isSandbox = isSandbox)
 
     val es2EventAsJsonString =
       encodeToJsonString(eventPayload, AnalyticsEventListenerPayload.CATALOG)
@@ -109,7 +114,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun eventListenerRemoved() {
     // Inner payload of the ES2 event.
     val eventPayload =
-      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = false)
+      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = false, isSandbox = isSandbox)
 
     val es2EventAsJsonString =
       encodeToJsonString(eventPayload, AnalyticsEventListenerPayload.CATALOG)
@@ -187,6 +192,12 @@ internal class PayKitAnalyticsEventDispatcherImpl(
     payKitAnalytics.scheduleForDelivery(EventStream2Event(es2EventAsJsonString))
   }
 
+  override fun shutdown() {
+    eventStreamDeliverHandler?.let {
+      payKitAnalytics.unregisterDeliveryHandler(it)
+    }
+  }
+
   private fun createOrUpdateAnalyticsPayload(
     paymentKitAction: PayKitPaymentAction,
     apiAction: Action,
@@ -215,6 +226,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
           createChannel = CHANNEL_IN_APP,
           createRedirectUrl = paymentKitAction.redirectUri,
           createReferenceId = paymentKitAction.accountReferenceId,
+          isSandbox = isSandbox,
         )
       }
 
@@ -229,6 +241,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
           createChannel = CHANNEL_IN_APP,
           createRedirectUrl = paymentKitAction.redirectUri,
           createReferenceId = null,
+          isSandbox = isSandbox,
         )
       }
     }
@@ -282,6 +295,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       customerCashTag = customerResponseData?.customerProfile?.cashTag,
       requestId = customerResponseData?.id,
       referenceId = customerResponseData?.referenceId,
+      isSandbox = isSandbox,
     )
   }
 

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
@@ -264,6 +264,7 @@ internal class CashAppPayKitImpl(
     callbackListener = null
     payKitLifecycleListener.unregister(this)
     analyticsEventDispatcher.eventListenerRemoved()
+    analyticsEventDispatcher.shutdown()
   }
 
   private fun enforceRegisteredStateUpdatesListener() {

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
@@ -27,4 +27,6 @@ open class AnalyticsBasePayload(
   open val requestPlatform: String,
 
   open val clientId: String,
+
+  open val isSandbox: Boolean,
 )

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
@@ -41,6 +41,9 @@ data class AnalyticsCustomerRequestPayload(
   @Json(name = "mobile_cap_pk_customer_request_client_id")
   override val clientId: String,
 
+  @Json(name = "mobile_cap_pk_customer_request_is_sandbox")
+  override val isSandbox: Boolean,
+
   /*
   * Create Request.
   */
@@ -176,7 +179,7 @@ data class AnalyticsCustomerRequestPayload(
   // The field of the error.
   @Json(name = "mobile_cap_pk_customer_request_error_field")
   val errorField: String? = null,
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_customer_request"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
@@ -40,6 +40,9 @@ class AnalyticsEventListenerPayload(
   @Json(name = "mobile_cap_pk_event_listener_client_id")
   clientId: String,
 
+  @Json(name = "mobile_cap_pk_event_listener_is_sandbox")
+  override val isSandbox: Boolean,
+
   /*
   * Event Specific fields.
    */
@@ -50,7 +53,7 @@ class AnalyticsEventListenerPayload(
   @Json(name = "mobile_cap_pk_event_listener_is_added")
   val isAdded: Boolean,
 
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_event_listener"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
@@ -40,7 +40,10 @@ class AnalyticsInitializationPayload(
   @Json(name = "mobile_cap_pk_initialization_client_id")
   clientId: String,
 
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId) {
+  @Json(name = "mobile_cap_pk_initialization_is_sandbox")
+  override val isSandbox: Boolean,
+
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_initialization"


### PR DESCRIPTION
This PR addresses things that came out of the QA party on March 1st:

1.  All Analytics catalogs have a newly added `is_sandbox` to help distinguish traffic of Sandbox and regular Prod
2. When selecting `staging` under the Dev app, the analytics weren't correctly routing to the staging analytics endpoint


# Verification

| staging analytics is being hit correctly now | is_sandbox is part of the new analytics payload |
| -- | -- |
| ![staging-events](https://user-images.githubusercontent.com/416941/222308593-556003ae-f7f2-49ab-8439-ae5263e7e0a6.png) | <img width="1020" alt="Screenshot 2023-03-01 at 5 31 39 PM" src="https://user-images.githubusercontent.com/416941/222308610-5a76c259-4205-405b-a16e-53329a752da9.png">
 |