### PR TITLE
License header with spotless

### DIFF
--- a/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsLogger.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsLogger.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import android.util.Log

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsOptions.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/AnalyticsOptions.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import android.util.Log

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
@@ -236,6 +236,19 @@ class PayKitAnalytics constructor(
     }
   }
 
+  @Synchronized
+  fun unregisterDeliveryHandler(handler: DeliveryHandler) {
+    deliveryHandlers.remove(handler)
+    logger.i(
+      TAG,
+      "Unregistering %s as delivery handler for %s".format(
+        Locale.US,
+        handler.javaClass.simpleName,
+        handler.deliverableType,
+      ),
+    )
+  }
+
   /**
    * Returns synchronization handler for given package type.
    *

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/PayKitAnalytics.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import android.content.Context

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/core/Deliverable.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/core/Deliverable.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.core
 
 /**

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryHandler.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryHandler.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.core
 
 import app.cash.paykit.analytics.AnalyticsLogger

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryListener.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryListener.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.core
 
 import app.cash.paykit.analytics.persistence.AnalyticEntry

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryWorker.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/core/DeliveryWorker.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.core
 
 import app.cash.paykit.analytics.AnalyticsLogger

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/AnalyticEntry.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/AnalyticEntry.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.persistence
 
 import android.database.Cursor

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/EntriesDataSource.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/EntriesDataSource.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.persistence
 
 import android.os.SystemClock

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/sqlite/AnalyticsSQLiteDataSource.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/sqlite/AnalyticsSQLiteDataSource.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.persistence.sqlite
 
 import android.content.ContentValues

--- a/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/sqlite/AnalyticsSqLiteHelper.kt
+++ b/analytics-core/src/main/java/app/cash/paykit/analytics/persistence/sqlite/AnalyticsSqLiteHelper.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics.persistence.sqlite
 
 import android.content.Context

--- a/analytics-core/src/test/java/app/cash/paykit/analytics/AnalyticsTest.kt
+++ b/analytics-core/src/test/java/app/cash/paykit/analytics/AnalyticsTest.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import android.content.Context

--- a/analytics-core/src/test/java/app/cash/paykit/analytics/DeliveryWorkerTest.kt
+++ b/analytics-core/src/test/java/app/cash/paykit/analytics/DeliveryWorkerTest.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import app.cash.paykit.analytics.core.DeliveryHandler

--- a/analytics-core/src/test/java/app/cash/paykit/analytics/SQLiteDataSourceTest.kt
+++ b/analytics-core/src/test/java/app/cash/paykit/analytics/SQLiteDataSourceTest.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import app.cash.paykit.analytics.Utils.getAllSyncEntries

--- a/analytics-core/src/test/java/app/cash/paykit/analytics/Utils.kt
+++ b/analytics-core/src/test/java/app/cash/paykit/analytics/Utils.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.analytics
 
 import android.content.ContentValues

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects { subproject ->
           'charset': 'utf-8',
           'indent_size': '2',
       ])
+      licenseHeaderFile(rootProject.file('gradle/license-header.txt'))
     }
     java {
       target("src/**/*.java")

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import android.content.Context

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
@@ -153,7 +153,7 @@ object CashAppPayKitFactory {
       okHttpClient = defaultOkHttpClient,
     )
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics, isSandbox = false)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppPayKitImpl(
@@ -179,7 +179,7 @@ object CashAppPayKitFactory {
     )
 
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, paykitAnalytics, isSandbox = true)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppPayKitImpl(
@@ -195,6 +195,7 @@ object CashAppPayKitFactory {
     clientId: String,
     networkManager: NetworkManager,
     eventsManager: PayKitAnalytics,
+    isSandbox: Boolean,
   ): PayKitAnalyticsEventDispatcher {
     val sdkVersion =
       ApplicationContextHolder.applicationContext.getString(R.string.cashpaykit_version)
@@ -202,6 +203,7 @@ object CashAppPayKitFactory {
       sdkVersion,
       clientId,
       getUserAgentValue(),
+      isSandbox,
       eventsManager,
       networkManager,
     )

--- a/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.models.analytics.EventStream2Response

--- a/core/src/main/java/app/cash/paykit/core/PayKitInitializer.kt
+++ b/core/src/main/java/app/cash/paykit/core/PayKitInitializer.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import android.content.Context

--- a/core/src/main/java/app/cash/paykit/core/PayKitLifecycleObserver.kt
+++ b/core/src/main/java/app/cash/paykit/core/PayKitLifecycleObserver.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.impl.PayKitLifecycleListener

--- a/core/src/main/java/app/cash/paykit/core/PayKitState.kt
+++ b/core/src/main/java/app/cash/paykit/core/PayKitState.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.models.response.CustomerResponseData

--- a/core/src/main/java/app/cash/paykit/core/analytics/EventStream2Event.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/EventStream2Event.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.analytics
 
 import app.cash.paykit.analytics.core.Deliverable

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.analytics
 
 import app.cash.paykit.core.PayKitState

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
@@ -54,4 +54,9 @@ internal interface PayKitAnalyticsEventDispatcher {
     payKitExceptionState: PayKitExceptionState,
     customerResponseData: CustomerResponseData?,
   )
+
+  /**
+   * Command this [PayKitAnalyticsEventDispatcher] to stop executing and discard.
+   */
+  fun shutdown()
 }

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -62,13 +62,16 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   private val sdkVersion: String,
   private val clientId: String,
   private val userAgent: String,
+  private val isSandbox: Boolean,
   private val payKitAnalytics: PayKitAnalytics,
   private val networkManager: NetworkManager,
   private val moshi: Moshi = Moshi.Builder().build(),
 ) : PayKitAnalyticsEventDispatcher {
 
+  private var eventStreamDeliverHandler: DeliveryHandler? = null
+
   init {
-    val eventStreamDeliverHandler = object : DeliveryHandler() {
+    eventStreamDeliverHandler = object : DeliveryHandler() {
 
       override val deliverableType = ESEventType
 
@@ -81,13 +84,15 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       }
     }
 
-    payKitAnalytics.registerDeliveryHandler(eventStreamDeliverHandler)
+    eventStreamDeliverHandler?.let {
+      payKitAnalytics.registerDeliveryHandler(it)
+    }
   }
 
   override fun sdkInitialized() {
     // Inner payload of the ES2 event.
     val initializationPayload =
-      AnalyticsInitializationPayload(sdkVersion, userAgent, PLATFORM, clientId)
+      AnalyticsInitializationPayload(sdkVersion, userAgent, PLATFORM, clientId, isSandbox)
 
     val es2EventAsJsonString =
       encodeToJsonString(initializationPayload, AnalyticsInitializationPayload.CATALOG)
@@ -99,7 +104,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun eventListenerAdded() {
     // Inner payload of the ES2 event.
     val eventPayload =
-      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = true)
+      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = true, isSandbox = isSandbox)
 
     val es2EventAsJsonString =
       encodeToJsonString(eventPayload, AnalyticsEventListenerPayload.CATALOG)
@@ -109,7 +114,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun eventListenerRemoved() {
     // Inner payload of the ES2 event.
     val eventPayload =
-      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = false)
+      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = false, isSandbox = isSandbox)
 
     val es2EventAsJsonString =
       encodeToJsonString(eventPayload, AnalyticsEventListenerPayload.CATALOG)
@@ -187,6 +192,12 @@ internal class PayKitAnalyticsEventDispatcherImpl(
     payKitAnalytics.scheduleForDelivery(EventStream2Event(es2EventAsJsonString))
   }
 
+  override fun shutdown() {
+    eventStreamDeliverHandler?.let {
+      payKitAnalytics.unregisterDeliveryHandler(it)
+    }
+  }
+
   private fun createOrUpdateAnalyticsPayload(
     paymentKitAction: PayKitPaymentAction,
     apiAction: Action,
@@ -215,6 +226,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
           createChannel = CHANNEL_IN_APP,
           createRedirectUrl = paymentKitAction.redirectUri,
           createReferenceId = paymentKitAction.accountReferenceId,
+          isSandbox = isSandbox,
         )
       }
 
@@ -229,6 +241,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
           createChannel = CHANNEL_IN_APP,
           createRedirectUrl = paymentKitAction.redirectUri,
           createReferenceId = null,
+          isSandbox = isSandbox,
         )
       }
     }
@@ -282,6 +295,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       customerCashTag = customerResponseData?.customerProfile?.cashTag,
       requestId = customerResponseData?.id,
       referenceId = customerResponseData?.referenceId,
+      isSandbox = isSandbox,
     )
   }
 

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.analytics
 
 import EventStream2Event

--- a/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.android
 
 import android.content.Context

--- a/core/src/main/java/app/cash/paykit/core/exceptions/PayKitApiNetworkException.kt
+++ b/core/src/main/java/app/cash/paykit/core/exceptions/PayKitApiNetworkException.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.exceptions
 
 import app.cash.paykit.core.exceptions.PayKitNetworkErrorType.API

--- a/core/src/main/java/app/cash/paykit/core/exceptions/PayKitConnectivityNetworkException.kt
+++ b/core/src/main/java/app/cash/paykit/core/exceptions/PayKitConnectivityNetworkException.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.exceptions
 
 import app.cash.paykit.core.exceptions.PayKitNetworkErrorType.CONNECTIVITY

--- a/core/src/main/java/app/cash/paykit/core/exceptions/PayKitIntegrationException.kt
+++ b/core/src/main/java/app/cash/paykit/core/exceptions/PayKitIntegrationException.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.exceptions
 
 /**

--- a/core/src/main/java/app/cash/paykit/core/exceptions/PayKitNetworkException.kt
+++ b/core/src/main/java/app/cash/paykit/core/exceptions/PayKitNetworkException.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.exceptions
 
 /**

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
@@ -264,6 +264,7 @@ internal class CashAppPayKitImpl(
     callbackListener = null
     payKitLifecycleListener.unregister(this)
     analyticsEventDispatcher.eventListenerRemoved()
+    analyticsEventDispatcher.shutdown()
   }
 
   private fun enforceRegisteredStateUpdatesListener() {

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.impl
 
 import android.content.ActivityNotFoundException

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.impl
 
 import app.cash.paykit.core.NetworkManager

--- a/core/src/main/java/app/cash/paykit/core/impl/PayKitLifecycleObserverImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/PayKitLifecycleObserverImpl.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.impl
 
 import android.os.Handler

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/AnalyticsEvent.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/AnalyticsEvent.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/AnalyticsRequest.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/AnalyticsRequest.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/AnalyticsResponse.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/AnalyticsResponse.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.analytics
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/EventStream2AnalyticsRequest.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/EventStream2AnalyticsRequest.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/EventStream2Event.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/EventStream2Event.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
@@ -27,4 +27,6 @@ open class AnalyticsBasePayload(
   open val requestPlatform: String,
 
   open val clientId: String,
+
+  open val isSandbox: Boolean,
 )

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.analytics.payloads
 
 open class AnalyticsBasePayload(

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
@@ -41,6 +41,9 @@ data class AnalyticsCustomerRequestPayload(
   @Json(name = "mobile_cap_pk_customer_request_client_id")
   override val clientId: String,
 
+  @Json(name = "mobile_cap_pk_customer_request_is_sandbox")
+  override val isSandbox: Boolean,
+
   /*
   * Create Request.
   */
@@ -176,7 +179,7 @@ data class AnalyticsCustomerRequestPayload(
   // The field of the error.
   @Json(name = "mobile_cap_pk_customer_request_error_field")
   val errorField: String? = null,
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_customer_request"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.analytics.payloads
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
@@ -40,6 +40,9 @@ class AnalyticsEventListenerPayload(
   @Json(name = "mobile_cap_pk_event_listener_client_id")
   clientId: String,
 
+  @Json(name = "mobile_cap_pk_event_listener_is_sandbox")
+  override val isSandbox: Boolean,
+
   /*
   * Event Specific fields.
    */
@@ -50,7 +53,7 @@ class AnalyticsEventListenerPayload(
   @Json(name = "mobile_cap_pk_event_listener_is_added")
   val isAdded: Boolean,
 
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_event_listener"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.analytics.payloads
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
@@ -40,7 +40,10 @@ class AnalyticsInitializationPayload(
   @Json(name = "mobile_cap_pk_initialization_client_id")
   clientId: String,
 
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId) {
+  @Json(name = "mobile_cap_pk_initialization_is_sandbox")
+  override val isSandbox: Boolean,
+
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_initialization"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.analytics.payloads
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/common/Action.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/common/Action.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.common
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/common/NetworkResult.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/common/NetworkResult.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.common
 
 /**

--- a/core/src/main/java/app/cash/paykit/core/models/request/CreateCustomerRequest.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/request/CreateCustomerRequest.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.request
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/request/CustomerRequestData.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/request/CustomerRequestData.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.request
 
 import app.cash.paykit.core.models.common.Action

--- a/core/src/main/java/app/cash/paykit/core/models/request/CustomerRequestDataFactory.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/request/CustomerRequestDataFactory.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.request
 
 import app.cash.paykit.core.models.common.Action

--- a/core/src/main/java/app/cash/paykit/core/models/response/ApiError.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/ApiError.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/response/ApiErrorResponse.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/ApiErrorResponse.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/response/AuthFlowTriggers.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/AuthFlowTriggers.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerProfile.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerProfile.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import app.cash.paykit.core.models.common.Action

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerTopLevelResponse.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerTopLevelResponse.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/response/Grant.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/Grant.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import app.cash.paykit.core.models.common.Action

--- a/core/src/main/java/app/cash/paykit/core/models/response/Origin.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/Origin.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/response/RequesterProfile.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/RequesterProfile.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.response
 
 import com.squareup.moshi.Json

--- a/core/src/main/java/app/cash/paykit/core/models/sdk/PayKitCurrency.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/sdk/PayKitCurrency.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.sdk
 
 /**

--- a/core/src/main/java/app/cash/paykit/core/models/sdk/PayKitPaymentAction.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/sdk/PayKitPaymentAction.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.models.sdk
 
 import app.cash.paykit.core.CashAppPayKit

--- a/core/src/main/java/app/cash/paykit/core/network/OkHttpProvider.kt
+++ b/core/src/main/java/app/cash/paykit/core/network/OkHttpProvider.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.network
 
 import okhttp3.OkHttpClient

--- a/core/src/main/java/app/cash/paykit/core/network/RetryManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/network/RetryManager.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.network
 
 import kotlin.time.Duration

--- a/core/src/main/java/app/cash/paykit/core/ui/CashPayKitButton.kt
+++ b/core/src/main/java/app/cash/paykit/core/ui/CashPayKitButton.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.ui
 
 import android.content.Context

--- a/core/src/main/java/app/cash/paykit/core/utils/Extensions.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/Extensions.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.utils
 
 /**

--- a/core/src/main/java/app/cash/paykit/core/utils/UserAgentProvider.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/UserAgentProvider.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core.utils
 
 import android.content.Context

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayKitAuthorizeTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayKitAuthorizeTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import android.content.Context

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayKitExceptionsTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayKitExceptionsTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.exceptions.PayKitIntegrationException

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayKitStateTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayKitStateTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import android.content.ActivityNotFoundException

--- a/core/src/test/java/app/cash/paykit/core/FakeData.kt
+++ b/core/src/test/java/app/cash/paykit/core/FakeData.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.models.sdk.PayKitCurrency.USD

--- a/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.PayKitState.PayKitExceptionState

--- a/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.NetworkErrorTests.MockListener

--- a/core/src/test/java/app/cash/paykit/core/PayKitLifecycleObserverTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/PayKitLifecycleObserverTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import androidx.lifecycle.Lifecycle

--- a/core/src/test/java/app/cash/paykit/core/UserAgentProviderTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/UserAgentProviderTests.kt
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2023 Cash App
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package app.cash.paykit.core
 
 import app.cash.paykit.core.utils.UserAgentProvider

--- a/gradle/license-header.txt
+++ b/gradle/license-header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Cash App
+ * Copyright (C) $YEAR Cash App
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.paykit.core.models.analytics
-
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
-data class EventStream2Response(
-  @Json(name = "failure_count")
-  val failureCount: Int,
-  @Json(name = "invalid_count")
-  val invalidCount: Int,
-  @Json(name = "success_count")
-  val successCount: Int,
-)


### PR DESCRIPTION
What I really like is to add a license header manually to each file - said no one, ever!

Previously we used IDE tooling to enforce this, but it was still pretty much a dev initiated action, therefore it was easy for new files to fall trough the cracks.
This change enforces the License Header from a template via the Spotless plugin.