### PR TITLE
WIP PoC activity callbacks

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
@@ -80,11 +80,9 @@ interface CashAppPayKit {
   /**
    * Authorize a customer request. This function must be called AFTER `createCustomerRequest`.
    * Not doing so will result in an Exception in sandbox mode, and a silent error log in production.
-   *
-   * @param context Android context class.
    */
   @Throws(IllegalArgumentException::class, PayKitIntegrationException::class)
-  fun authorizeCustomerRequest(context: Context)
+  fun authorizeCustomerRequest()
 
   /**
    * Authorize a customer request with a previously created `customerData`.
@@ -93,7 +91,6 @@ interface CashAppPayKit {
    */
   @Throws(IllegalArgumentException::class, RuntimeException::class)
   fun authorizeCustomerRequest(
-    context: Context,
     customerData: CustomerResponseData,
   )
 

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayKit.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.paykit.core
 
-import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.WorkerThread

--- a/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
@@ -16,6 +16,7 @@
 package app.cash.paykit.core.android
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import java.lang.ref.WeakReference
 
 /**
@@ -36,4 +37,9 @@ internal object ApplicationContextHolder {
 
   val applicationContext: Context
     get() = applicationContextReference.get()!!
+
+  @VisibleForTesting
+  fun clearApplicationRef() {
+    isInitialized = false
+  }
 }

--- a/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
@@ -15,12 +15,7 @@
  */
 package app.cash.paykit.core.android
 
-import android.annotation.SuppressLint
-import android.app.Activity
-import android.app.Application
-import android.app.Application.ActivityLifecycleCallbacks
 import android.content.Context
-import android.os.Bundle
 import java.lang.ref.WeakReference
 
 /**
@@ -30,9 +25,6 @@ internal object ApplicationContextHolder {
   private var isInitialized: Boolean = false
 
   private lateinit var applicationContextReference: WeakReference<Context>
-  private var currentActivityReference: WeakReference<Activity>? = null
-
-  fun getCurrentActivity() = currentActivityReference?.get()
 
   fun init(applicationContext: Context) {
     if (isInitialized) {
@@ -40,32 +32,6 @@ internal object ApplicationContextHolder {
     }
     isInitialized = true
     applicationContextReference = WeakReference(applicationContext.applicationContext)
-
-    val app = applicationContext as Application
-    app.registerActivityLifecycleCallbacks(object :ActivityLifecycleCallbacks{
-      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-      }
-
-      override fun onActivityStarted(activity: Activity) {
-      }
-
-      override fun onActivityResumed(activity: Activity) {
-        currentActivityReference?.clear()
-        currentActivityReference = WeakReference(activity)
-      }
-
-      override fun onActivityPaused(activity: Activity) {
-      }
-
-      override fun onActivityStopped(activity: Activity) {
-      }
-
-      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-      }
-
-      override fun onActivityDestroyed(activity: Activity) {
-      }
-    })
   }
 
   val applicationContext: Context

--- a/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/ApplicationContextHolder.kt
@@ -17,7 +17,12 @@
 
 package app.cash.paykit.core.android
 
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Application
+import android.app.Application.ActivityLifecycleCallbacks
 import android.content.Context
+import android.os.Bundle
 import java.lang.ref.WeakReference
 
 /**
@@ -27,6 +32,9 @@ internal object ApplicationContextHolder {
   private var isInitialized: Boolean = false
 
   private lateinit var applicationContextReference: WeakReference<Context>
+  private var currentActivityReference: WeakReference<Activity>? = null
+
+  fun getCurrentActivity() = currentActivityReference?.get()
 
   fun init(applicationContext: Context) {
     if (isInitialized) {
@@ -34,6 +42,32 @@ internal object ApplicationContextHolder {
     }
     isInitialized = true
     applicationContextReference = WeakReference(applicationContext.applicationContext)
+
+    val app = applicationContext as Application
+    app.registerActivityLifecycleCallbacks(object :ActivityLifecycleCallbacks{
+      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+      }
+
+      override fun onActivityStarted(activity: Activity) {
+      }
+
+      override fun onActivityResumed(activity: Activity) {
+        currentActivityReference?.clear()
+        currentActivityReference = WeakReference(activity)
+      }
+
+      override fun onActivityPaused(activity: Activity) {
+      }
+
+      override fun onActivityStopped(activity: Activity) {
+      }
+
+      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+      }
+
+      override fun onActivityDestroyed(activity: Activity) {
+      }
+    })
   }
 
   val applicationContext: Context

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
@@ -227,6 +227,7 @@ internal class CashAppPayKitImpl(
     }
     // Open Mobile URL provided by backend response.
     val intent = Intent(Intent.ACTION_VIEW)
+    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
     intent.data = try {
       Uri.parse(customerData.authFlowTriggers?.mobileUrl)
     } catch (error: NullPointerException) {
@@ -237,7 +238,7 @@ internal class CashAppPayKitImpl(
     customerResponseData = customerData
 
     try {
-      ApplicationContextHolder.getCurrentActivity()!!.startActivity(intent)
+      ApplicationContextHolder.applicationContext.startActivity(intent)
     } catch (activityNotFoundException: ActivityNotFoundException) {
       currentState = PayKitExceptionState(PayKitIntegrationException("Unable to open mobileUrl: ${customerData.authFlowTriggers?.mobileUrl}"))
       return

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
@@ -16,7 +16,6 @@
 package app.cash.paykit.core.impl
 
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayKitImpl.kt
@@ -40,6 +40,7 @@ import app.cash.paykit.core.PayKitState.ReadyToAuthorize
 import app.cash.paykit.core.PayKitState.RetrievingExistingCustomerRequest
 import app.cash.paykit.core.PayKitState.UpdatingCustomerRequest
 import app.cash.paykit.core.analytics.PayKitAnalyticsEventDispatcher
+import app.cash.paykit.core.android.ApplicationContextHolder
 import app.cash.paykit.core.exceptions.PayKitIntegrationException
 import app.cash.paykit.core.models.common.NetworkResult.Failure
 import app.cash.paykit.core.models.common.NetworkResult.Success
@@ -195,11 +196,9 @@ internal class CashAppPayKitImpl(
   /**
    * Authorize a customer request. This function must be called AFTER `createCustomerRequest`.
    * Not doing so will result in an Exception in sandbox mode, and a silent error log in production.
-   *
-   * @param context Android context class.
    */
   @Throws(IllegalArgumentException::class, PayKitIntegrationException::class)
-  override fun authorizeCustomerRequest(context: Context) {
+  override fun authorizeCustomerRequest() {
     val customerData = customerResponseData
 
     if (customerData == null) {
@@ -211,7 +210,7 @@ internal class CashAppPayKitImpl(
       return
     }
 
-    authorizeCustomerRequest(context, customerData)
+    authorizeCustomerRequest(customerData)
   }
 
   /**
@@ -221,7 +220,6 @@ internal class CashAppPayKitImpl(
    */
   @Throws(IllegalArgumentException::class, RuntimeException::class)
   override fun authorizeCustomerRequest(
-    context: Context,
     customerData: CustomerResponseData,
   ) {
     enforceRegisteredStateUpdatesListener()
@@ -241,7 +239,7 @@ internal class CashAppPayKitImpl(
     customerResponseData = customerData
 
     try {
-      context.startActivity(intent)
+      ApplicationContextHolder.getCurrentActivity()!!.startActivity(intent)
     } catch (activityNotFoundException: ActivityNotFoundException) {
       currentState = PayKitExceptionState(PayKitIntegrationException("Unable to open mobileUrl: ${customerData.authFlowTriggers?.mobileUrl}"))
       return

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayKitAuthorizeTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayKitAuthorizeTests.kt
@@ -40,14 +40,14 @@ class CashAppPayKitAuthorizeTests {
   fun `should throw if calling authorize before createCustomer`() {
     val payKit = createPayKit()
     payKit.registerForStateUpdates(mockk())
-    payKit.authorizeCustomerRequest(context)
+    payKit.authorizeCustomerRequest()
   }
 
   @Test(expected = PayKitIntegrationException::class)
   fun `should throw on authorizeCustomerRequest if has NOT registered for state updates`() {
     val payKit = createPayKit()
     val customerResponseData = mockk<CustomerResponseData>(relaxed = true)
-    payKit.authorizeCustomerRequest(context, customerResponseData)
+    payKit.authorizeCustomerRequest(customerResponseData)
   }
 
   @Test(expected = IllegalArgumentException::class)
@@ -56,7 +56,7 @@ class CashAppPayKitAuthorizeTests {
     val customerResponseData = mockk<CustomerResponseData>(relaxed = true)
     payKit.registerForStateUpdates(mockk())
 
-    payKit.authorizeCustomerRequest(context, customerResponseData)
+    payKit.authorizeCustomerRequest(customerResponseData)
   }
 
   @Test(expected = IllegalArgumentException::class)
@@ -67,7 +67,7 @@ class CashAppPayKitAuthorizeTests {
     }
     payKit.registerForStateUpdates(mockk())
 
-    payKit.authorizeCustomerRequest(context, customerResponseData)
+    payKit.authorizeCustomerRequest(customerResponseData)
   }
 
   @Test(expected = RuntimeException::class)
@@ -80,7 +80,7 @@ class CashAppPayKitAuthorizeTests {
     }
     payKit.registerForStateUpdates(mockk())
 
-    payKit.authorizeCustomerRequest(context, customerResponseData)
+    payKit.authorizeCustomerRequest(customerResponseData)
   }
 
   private fun createPayKit() =


### PR DESCRIPTION
Slack convo (feedback from merchant)
https://cash.slack.com/archives/C03V6LVHTC1/p1678131575975969

We initially implemented the API before we utilized the `androidx.startup.Initializer` process... 

Since we now have access to the Application object at app startup, we can attach Activity listeners, and use them in our code for authorizing a customer request.

This is a PoC only. More cleanup required. 
We probably want to make a separate class for this, so we have good SOC. 

 