### PR TITLE
Add environment property to Analytics 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,16 @@
-# TODO
+# 1.0.7
+
+ - Breaking change: `authorizeCustomerRequest` no longer requires a `context` to be passed as a parameter
+ - Breaking change: several class names have changed to better align across platforms. The gist of it, is that `PayKit` becomes `CashAppPay`
+
+Class renaming correspondence:
+
+`PayKitState` -> `CashAppPayState`
+`PayKitExceptionState` -> `CashAppPayExceptionState`
+`PayKitCurrency` -> `CashAppPayCurrency`
+`PayKitPaymentAction` -> `CashAppPayPaymentAction`
+`CashAppPayKit` -> `CashAppPay`
+`CashAppPayKitFactory` -> `CashAppPayFactory`
+`CashAppPayKitListener` -> `CashAppPayListener`
+`CashPayKitLightButton` -> `CashAppPayLightButton`
+`CashPayKitDarkButton` -> `CashAppPayDarkButton`

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -153,7 +153,7 @@ object CashAppPayFactory {
     )
     val analytics = buildPayKitAnalytics(isSandbox = false)
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, isSandbox = false)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, ANALYTICS_PROD_ENVIRONMENT)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppCashAppPayImpl(
@@ -180,7 +180,7 @@ object CashAppPayFactory {
 
     val analytics = buildPayKitAnalytics(isSandbox = true)
     val analyticsEventDispatcher =
-      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, isSandbox = true)
+      buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, ANALYTICS_SANDBOX_ENVIRONMENT)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
     return CashAppCashAppPayImpl(
@@ -196,7 +196,7 @@ object CashAppPayFactory {
     clientId: String,
     networkManager: NetworkManager,
     eventsManager: PayKitAnalytics,
-    isSandbox: Boolean,
+    environment: String,
   ): PayKitAnalyticsEventDispatcher {
     val sdkVersion =
       ApplicationContextHolder.applicationContext.getString(R.string.cap_version)
@@ -204,7 +204,7 @@ object CashAppPayFactory {
       sdkVersion,
       clientId,
       getUserAgentValue(),
-      isSandbox,
+      environment,
       eventsManager,
       networkManager,
     )
@@ -218,6 +218,8 @@ object CashAppPayFactory {
   private val ANALYTICS_BASE_URL = "https://api.squareup.com/"
   private val ANALYTICS_DB_NAME_PROD = "paykit-events.db"
   private val ANALYTICS_DB_NAME_SANDBOX = "paykit-events-sandbox.db"
+  private val ANALYTICS_PROD_ENVIRONMENT = "production"
+  private val ANALYTICS_SANDBOX_ENVIRONMENT = "sandbox"
 }
 
 interface CashAppPayListener {

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -60,7 +60,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   private val sdkVersion: String,
   private val clientId: String,
   private val userAgent: String,
-  private val isSandbox: Boolean,
+  private val sdkEnvironment: String,
   private val payKitAnalytics: PayKitAnalytics,
   private val networkManager: NetworkManager,
   private val moshi: Moshi = Moshi.Builder().build(),
@@ -90,7 +90,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun sdkInitialized() {
     // Inner payload of the ES2 event.
     val initializationPayload =
-      AnalyticsInitializationPayload(sdkVersion, userAgent, PLATFORM, clientId, isSandbox)
+      AnalyticsInitializationPayload(sdkVersion, userAgent, PLATFORM, clientId, sdkEnvironment)
 
     val es2EventAsJsonString =
       encodeToJsonString(initializationPayload, AnalyticsInitializationPayload.CATALOG)
@@ -102,7 +102,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun eventListenerAdded() {
     // Inner payload of the ES2 event.
     val eventPayload =
-      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = true, isSandbox = isSandbox)
+      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = true, environment = sdkEnvironment)
 
     val es2EventAsJsonString =
       encodeToJsonString(eventPayload, AnalyticsEventListenerPayload.CATALOG)
@@ -112,7 +112,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   override fun eventListenerRemoved() {
     // Inner payload of the ES2 event.
     val eventPayload =
-      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = false, isSandbox = isSandbox)
+      AnalyticsEventListenerPayload(sdkVersion, userAgent, PLATFORM, clientId, isAdded = false, environment = sdkEnvironment)
 
     val es2EventAsJsonString =
       encodeToJsonString(eventPayload, AnalyticsEventListenerPayload.CATALOG)
@@ -222,7 +222,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
           createChannel = CHANNEL_IN_APP,
           createRedirectUrl = paymentKitAction.redirectUri,
           createReferenceId = paymentKitAction.accountReferenceId,
-          isSandbox = isSandbox,
+          environment = sdkEnvironment,
         )
       }
 
@@ -237,7 +237,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
           createChannel = CHANNEL_IN_APP,
           createRedirectUrl = paymentKitAction.redirectUri,
           createReferenceId = null,
-          isSandbox = isSandbox,
+          environment = sdkEnvironment,
         )
       }
     }
@@ -291,7 +291,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       customerCashTag = customerResponseData?.customerProfile?.cashTag,
       requestId = customerResponseData?.id,
       referenceId = customerResponseData?.referenceId,
-      isSandbox = isSandbox,
+      environment = sdkEnvironment,
     )
   }
 

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsBasePayload.kt
@@ -26,5 +26,6 @@ open class AnalyticsBasePayload(
 
   open val clientId: String,
 
-  open val isSandbox: Boolean,
+  // Environment the SDK is running against. E.: production, sandbox, staging, etc.
+  open val environment: String,
 )

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsCustomerRequestPayload.kt
@@ -39,8 +39,8 @@ data class AnalyticsCustomerRequestPayload(
   @Json(name = "mobile_cap_pk_customer_request_client_id")
   override val clientId: String,
 
-  @Json(name = "mobile_cap_pk_customer_request_is_sandbox")
-  override val isSandbox: Boolean,
+  @Json(name = "mobile_cap_pk_customer_request_environment")
+  override val environment: String,
 
   /*
   * Create Request.
@@ -177,7 +177,7 @@ data class AnalyticsCustomerRequestPayload(
   // The field of the error.
   @Json(name = "mobile_cap_pk_customer_request_error_field")
   val errorField: String? = null,
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, environment) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_customer_request"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsEventListenerPayload.kt
@@ -38,8 +38,8 @@ class AnalyticsEventListenerPayload(
   @Json(name = "mobile_cap_pk_event_listener_client_id")
   clientId: String,
 
-  @Json(name = "mobile_cap_pk_event_listener_is_sandbox")
-  override val isSandbox: Boolean,
+  @Json(name = "mobile_cap_pk_event_listener_environment")
+  override val environment: String,
 
   /*
   * Event Specific fields.
@@ -51,7 +51,7 @@ class AnalyticsEventListenerPayload(
   @Json(name = "mobile_cap_pk_event_listener_is_added")
   val isAdded: Boolean,
 
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, environment) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_event_listener"

--- a/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/analytics/payloads/AnalyticsInitializationPayload.kt
@@ -38,10 +38,10 @@ class AnalyticsInitializationPayload(
   @Json(name = "mobile_cap_pk_initialization_client_id")
   clientId: String,
 
-  @Json(name = "mobile_cap_pk_initialization_is_sandbox")
-  override val isSandbox: Boolean,
+  @Json(name = "mobile_cap_pk_initialization_environment")
+  override val environment: String,
 
-) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, isSandbox) {
+) : AnalyticsBasePayload(sdkVersion, clientUserAgent, requestPlatform, clientId, environment) {
 
   companion object {
     const val CATALOG = "mobile_cap_pk_initialization"


### PR DESCRIPTION
We've added a new `environment` property to analytics, to help differentiate analytics traffic.


## Verification

All 3 event catalogs are being consumed correctly. Below is one of them as seen on the RT console for ES2 ingestion. 

<img width="1251" alt="Screenshot 2023-03-17 at 1 14 02 PM" src="https://user-images.githubusercontent.com/416941/226026158-2d363400-9fdc-4fe1-b5c8-36814a7545f1.png">
