### PR TITLE
Support concurrent actions per customer request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew lint spotlessCheck
 
       - name: Unit Tests
-        run: ./gradlew test
+        run: ./gradlew testRelease testDebug
 
       - name: Build
         run: ./gradlew core:assemble

--- a/build.gradle
+++ b/build.gradle
@@ -50,11 +50,11 @@ subprojects { subproject ->
     }
   }
 }
-def NEXT_VERSION = "1.0.9-SNAPSHOT"
+def NEXT_VERSION = "2.0.1-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '1.0.8'
+  version = '2.0.0-SNAPSHOT'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -39,11 +39,12 @@ interface CashAppPay {
    *
    * Must be called from a background thread.
    *
-   * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer request.
+   * @param redirectUri The URI for Cash App to redirect back to your app.
+   * @param paymentActions A wrapper class that contains all of the necessary ingredients for building one or more customer requests.
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
-  fun createCustomerRequest(paymentAction: CashAppPayPaymentAction)
+  fun createCustomerRequest(redirectUri: String, paymentActions: List<CashAppPayPaymentAction>)
 
   /**
    * Update an existing customer request given its [requestId] an the updated definitions contained within [CashAppPayPaymentAction].
@@ -51,13 +52,13 @@ interface CashAppPay {
    * Must be called from a background thread.
    *
    * @param requestId ID of the request we intent do update.
-   * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer request.
+   * @param paymentActions A wrapper class that contains all of the necessary ingredients for updating one more more customer requests that share the same [requestId].
    *                      Look at [CashAppPayPaymentAction] for more details.
    */
   @WorkerThread
   fun updateCustomerRequest(
     requestId: String,
-    paymentAction: CashAppPayPaymentAction,
+    paymentActions: List<CashAppPayPaymentAction>,
   )
 
   /**

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -40,24 +40,24 @@ interface CashAppPay {
    *
    * Must be called from a background thread.
    *
-   * @param redirectUri The URI for Cash App to redirect back to your app. If you do not set this, back navigation from CashApp might not work as intended.
    * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer requests.
    *                      Look at [PayKitPaymentAction] for more details.
+   * @param redirectUri The URI for Cash App to redirect back to your app. If you do not set this, back navigation from CashApp might not work as intended.
    */
   @WorkerThread
-  fun createCustomerRequest(redirectUri: String?, paymentAction: CashAppPayPaymentAction)
+  fun createCustomerRequest(paymentAction: CashAppPayPaymentAction, redirectUri: String?)
 
   /**
    * Create customer request given list of [CashAppPayPaymentAction].
    *
    * Must be called from a background thread.
    *
-   * @param redirectUri The URI for Cash App to redirect back to your app. If you do not set this, back navigation from CashApp might not work as intended.
    * @param paymentActions A wrapper class that contains all of the necessary ingredients for building one or more customer requests.
    *                      Look at [PayKitPaymentAction] for more details.
+   * @param redirectUri The URI for Cash App to redirect back to your app. If you do not set this, back navigation from CashApp might not work as intended.
    */
   @WorkerThread
-  fun createCustomerRequest(redirectUri: String?, paymentActions: List<CashAppPayPaymentAction>)
+  fun createCustomerRequest(paymentActions: List<CashAppPayPaymentAction>, redirectUri: String?)
 
   /**
    * Update an existing customer request given its [requestId] and the updated definitions contained within [CashAppPayPaymentAction].

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -45,7 +45,7 @@ interface CashAppPay {
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
-  fun createCustomerRequest(redirectUri: String, paymentAction: CashAppPayPaymentAction)
+  fun createCustomerRequest(redirectUri: String?, paymentAction: CashAppPayPaymentAction)
 
   /**
    * Create customer request given list of [CashAppPayPaymentAction].
@@ -57,7 +57,7 @@ interface CashAppPay {
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
-  fun createCustomerRequest(redirectUri: String, paymentActions: List<CashAppPayPaymentAction>)
+  fun createCustomerRequest(redirectUri: String?, paymentActions: List<CashAppPayPaymentAction>)
 
   /**
    * Update an existing customer request given its [requestId] and the updated definitions contained within [CashAppPayPaymentAction].

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -34,8 +34,21 @@ import app.cash.paykit.core.utils.UserAgentProvider
 import kotlin.time.Duration.Companion.seconds
 
 interface CashAppPay {
+
   /**
    * Create customer request given a [CashAppPayPaymentAction].
+   *
+   * Must be called from a background thread.
+   *
+   * @param redirectUri The URI for Cash App to redirect back to your app.
+   * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer requests.
+   *                      Look at [PayKitPaymentAction] for more details.
+   */
+  @WorkerThread
+  fun createCustomerRequest(redirectUri: String, paymentAction: CashAppPayPaymentAction)
+
+  /**
+   * Create customer request given list of [CashAppPayPaymentAction].
    *
    * Must be called from a background thread.
    *
@@ -47,7 +60,22 @@ interface CashAppPay {
   fun createCustomerRequest(redirectUri: String, paymentActions: List<CashAppPayPaymentAction>)
 
   /**
-   * Update an existing customer request given its [requestId] an the updated definitions contained within [CashAppPayPaymentAction].
+   * Update an existing customer request given its [requestId] and the updated definitions contained within [CashAppPayPaymentAction].
+   *
+   * Must be called from a background thread.
+   *
+   * @param requestId ID of the request we intent do update.
+   * @param paymentAction A wrapper class that contains all of the necessary ingredients for updating a customer request for a given [requestId].
+   *                      Look at [CashAppPayPaymentAction] for more details.
+   */
+  @WorkerThread
+  fun updateCustomerRequest(
+    requestId: String,
+    paymentAction: CashAppPayPaymentAction,
+  )
+
+  /**
+   * Update an existing customer request given its [requestId] and the updated definitions contained within a list of [CashAppPayPaymentAction].
    *
    * Must be called from a background thread.
    *

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -40,7 +40,7 @@ interface CashAppPay {
    *
    * Must be called from a background thread.
    *
-   * @param redirectUri The URI for Cash App to redirect back to your app.
+   * @param redirectUri The URI for Cash App to redirect back to your app. If you do not set this, back navigation from CashApp might not work as intended.
    * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer requests.
    *                      Look at [PayKitPaymentAction] for more details.
    */
@@ -52,7 +52,7 @@ interface CashAppPay {
    *
    * Must be called from a background thread.
    *
-   * @param redirectUri The URI for Cash App to redirect back to your app.
+   * @param redirectUri The URI for Cash App to redirect back to your app. If you do not set this, back navigation from CashApp might not work as intended.
    * @param paymentActions A wrapper class that contains all of the necessary ingredients for building one or more customer requests.
    *                      Look at [PayKitPaymentAction] for more details.
    */

--- a/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
@@ -26,7 +26,7 @@ internal interface NetworkManager {
   @Throws(IOException::class)
   fun createCustomerRequest(
     clientId: String,
-    redirectUri: String,
+    redirectUri: String?,
     paymentActions: List<CashAppPayPaymentAction>,
   ): NetworkResult<CustomerTopLevelResponse>
 

--- a/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
@@ -26,8 +26,8 @@ internal interface NetworkManager {
   @Throws(IOException::class)
   fun createCustomerRequest(
     clientId: String,
-    redirectUri: String?,
     paymentActions: List<CashAppPayPaymentAction>,
+    redirectUri: String?,
   ): NetworkResult<CustomerTopLevelResponse>
 
   @Throws(IOException::class)

--- a/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/NetworkManager.kt
@@ -26,14 +26,15 @@ internal interface NetworkManager {
   @Throws(IOException::class)
   fun createCustomerRequest(
     clientId: String,
-    paymentAction: CashAppPayPaymentAction,
+    redirectUri: String,
+    paymentActions: List<CashAppPayPaymentAction>,
   ): NetworkResult<CustomerTopLevelResponse>
 
   @Throws(IOException::class)
   fun updateCustomerRequest(
     clientId: String,
     requestId: String,
-    paymentAction: CashAppPayPaymentAction,
+    paymentActions: List<CashAppPayPaymentAction>,
   ): NetworkResult<CustomerTopLevelResponse>
 
   fun retrieveUpdatedRequestData(

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
@@ -36,7 +36,7 @@ internal interface PayKitAnalyticsEventDispatcher {
   fun createdCustomerRequest(
     paymentKitActions: List<CashAppPayPaymentAction>,
     apiActions: List<Action>,
-    redirectUri: String,
+    redirectUri: String?,
   )
 
   fun updatedCustomerRequest(

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcher.kt
@@ -34,14 +34,15 @@ internal interface PayKitAnalyticsEventDispatcher {
   fun eventListenerRemoved()
 
   fun createdCustomerRequest(
-    paymentKitAction: CashAppPayPaymentAction,
-    apiAction: Action,
+    paymentKitActions: List<CashAppPayPaymentAction>,
+    apiActions: List<Action>,
+    redirectUri: String,
   )
 
   fun updatedCustomerRequest(
     requestId: String,
-    paymentKitAction: CashAppPayPaymentAction,
-    apiAction: Action,
+    paymentKitActions: List<CashAppPayPaymentAction>,
+    apiActions: List<Action>,
   )
 
   fun genericStateChanged(cashAppPayState: CashAppPayState, customerResponseData: CustomerResponseData?)

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -117,6 +117,14 @@ internal class CashAppCashAppPayImpl(
   @WorkerThread
   override fun createCustomerRequest(redirectUri: String, paymentActions: List<CashAppPayPaymentAction>) {
     enforceRegisteredStateUpdatesListener()
+
+    // Validate [paymentActions] is not empty.
+    if (paymentActions.isEmpty()) {
+      val exceptionText = "paymentAction should not be empty"
+      currentState = softCrashOrStateException(CashAppPayIntegrationException(exceptionText))
+      return
+    }
+
     currentState = CreatingCustomerRequest
 
     // Network call.
@@ -151,6 +159,14 @@ internal class CashAppCashAppPayImpl(
     paymentActions: List<CashAppPayPaymentAction>,
   ) {
     enforceRegisteredStateUpdatesListener()
+
+    // Validate [paymentActions] is not empty.
+    if (paymentActions.isEmpty()) {
+      val exceptionText = "paymentAction should not be empty"
+      currentState = softCrashOrStateException(CashAppPayIntegrationException(exceptionText))
+      return
+    }
+
     currentState = UpdatingCustomerRequest
 
     // Network request.
@@ -324,6 +340,18 @@ internal class CashAppCashAppPayImpl(
     if (useSandboxEnvironment || BuildConfig.DEBUG) {
       throw exception
     }
+  }
+
+  /**
+   * This function will throw the provided [exception] during development, or change the SDK state to [CashAppPayExceptionState] otherwise.
+   */
+  @Throws
+  private fun softCrashOrStateException(exception: Exception): CashAppPayExceptionState {
+    logError("Error occurred. E.: $exception")
+    if (useSandboxEnvironment || BuildConfig.DEBUG) {
+      throw exception
+    }
+    return CashAppPayExceptionState(exception)
   }
 
   private fun setStateFinished(wasSuccessful: Boolean) {

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -103,7 +103,7 @@ internal class CashAppCashAppPayImpl(
     analyticsEventDispatcher.sdkInitialized()
   }
 
-  override fun createCustomerRequest(redirectUri: String, paymentAction: CashAppPayPaymentAction) {
+  override fun createCustomerRequest(redirectUri: String?, paymentAction: CashAppPayPaymentAction) {
     createCustomerRequest(redirectUri, listOf(paymentAction))
   }
 
@@ -115,7 +115,7 @@ internal class CashAppCashAppPayImpl(
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
-  override fun createCustomerRequest(redirectUri: String, paymentActions: List<CashAppPayPaymentAction>) {
+  override fun createCustomerRequest(redirectUri: String?, paymentActions: List<CashAppPayPaymentAction>) {
     enforceRegisteredStateUpdatesListener()
 
     // Validate [paymentActions] is not empty.

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -61,8 +61,6 @@ internal class CashAppCashAppPayImpl(
   initialCustomerResponseData: CustomerResponseData? = null,
 ) : CashAppPay, CashAppPayLifecycleListener {
 
-  // TODO: Check if a given API call is allowed against a given internal SDK state. ( https://www.notion.so/cashappcash/Check-if-a-given-API-call-is-allowed-against-current-internal-SDK-state-0073051cd5aa42c7b9672542e9576f85 )
-
   private var callbackListener: CashAppPayListener? = null
 
   private var customerResponseData: CustomerResponseData? = initialCustomerResponseData
@@ -103,8 +101,8 @@ internal class CashAppCashAppPayImpl(
     analyticsEventDispatcher.sdkInitialized()
   }
 
-  override fun createCustomerRequest(redirectUri: String?, paymentAction: CashAppPayPaymentAction) {
-    createCustomerRequest(redirectUri, listOf(paymentAction))
+  override fun createCustomerRequest(paymentAction: CashAppPayPaymentAction, redirectUri: String?) {
+    createCustomerRequest(listOf(paymentAction), redirectUri)
   }
 
   /**
@@ -115,7 +113,7 @@ internal class CashAppCashAppPayImpl(
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
-  override fun createCustomerRequest(redirectUri: String?, paymentActions: List<CashAppPayPaymentAction>) {
+  override fun createCustomerRequest(paymentActions: List<CashAppPayPaymentAction>, redirectUri: String?) {
     enforceRegisteredStateUpdatesListener()
 
     // Validate [paymentActions] is not empty.
@@ -128,7 +126,7 @@ internal class CashAppCashAppPayImpl(
     currentState = CreatingCustomerRequest
 
     // Network call.
-    val networkResult = networkManager.createCustomerRequest(clientId, redirectUri, paymentActions)
+    val networkResult = networkManager.createCustomerRequest(clientId, paymentActions, redirectUri)
     when (networkResult) {
       is Failure -> {
         currentState = CashAppPayExceptionState(networkResult.exception)

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -111,12 +111,12 @@ internal class CashAppCashAppPayImpl(
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
-  override fun createCustomerRequest(paymentAction: CashAppPayPaymentAction) {
+  override fun createCustomerRequest(redirectUri: String, paymentActions: List<CashAppPayPaymentAction>) {
     enforceRegisteredStateUpdatesListener()
     currentState = CreatingCustomerRequest
 
     // Network call.
-    val networkResult = networkManager.createCustomerRequest(clientId, paymentAction)
+    val networkResult = networkManager.createCustomerRequest(clientId, redirectUri, paymentActions)
     when (networkResult) {
       is Failure -> {
         currentState = CashAppPayExceptionState(networkResult.exception)
@@ -140,13 +140,13 @@ internal class CashAppCashAppPayImpl(
   @WorkerThread
   override fun updateCustomerRequest(
     requestId: String,
-    paymentAction: CashAppPayPaymentAction,
+    paymentActions: List<CashAppPayPaymentAction>,
   ) {
     enforceRegisteredStateUpdatesListener()
     currentState = UpdatingCustomerRequest
 
     // Network request.
-    val networkResult = networkManager.updateCustomerRequest(clientId, requestId, paymentAction)
+    val networkResult = networkManager.updateCustomerRequest(clientId, requestId, paymentActions)
     when (networkResult) {
       is Failure -> {
         currentState = CashAppPayExceptionState(networkResult.exception)

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -103,11 +103,15 @@ internal class CashAppCashAppPayImpl(
     analyticsEventDispatcher.sdkInitialized()
   }
 
+  override fun createCustomerRequest(redirectUri: String, paymentAction: CashAppPayPaymentAction) {
+    createCustomerRequest(redirectUri, listOf(paymentAction))
+  }
+
   /**
    * Create customer request given a [CashAppPayPaymentAction].
    * Must be called from a background thread.
    *
-   * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer request.
+   * @param paymentActions A wrapper class that contains all of the necessary ingredients for building a customer request.
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread
@@ -129,12 +133,16 @@ internal class CashAppCashAppPayImpl(
     }
   }
 
+  override fun updateCustomerRequest(requestId: String, paymentAction: CashAppPayPaymentAction) {
+    updateCustomerRequest(requestId, listOf(paymentAction))
+  }
+
   /**
    * Update an existing customer request given its [requestId] an the updated definitions contained within [CashAppPayPaymentAction].
    * Must be called from a background thread.
    *
    * @param requestId ID of the request we intent do update.
-   * @param paymentAction A wrapper class that contains all of the necessary ingredients for building a customer request.
+   * @param paymentActions A wrapper class that contains all of the necessary ingredients for building a customer request.
    *                      Look at [PayKitPaymentAction] for more details.
    */
   @WorkerThread

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -78,8 +78,8 @@ internal class NetworkManagerImpl(
   @Throws(IOException::class)
   override fun createCustomerRequest(
     clientId: String,
-    redirectUri: String?,
     paymentActions: List<CashAppPayPaymentAction>,
+    redirectUri: String?,
   ): NetworkResult<CustomerTopLevelResponse> {
     val customerRequestData = CustomerRequestDataFactory.build(clientId, redirectUri, paymentActions)
     val createCustomerRequest = CreateCustomerRequest(

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -78,16 +78,17 @@ internal class NetworkManagerImpl(
   @Throws(IOException::class)
   override fun createCustomerRequest(
     clientId: String,
-    paymentAction: CashAppPayPaymentAction,
+    redirectUri: String,
+    paymentActions: List<CashAppPayPaymentAction>,
   ): NetworkResult<CustomerTopLevelResponse> {
-    val customerRequestData = CustomerRequestDataFactory.build(clientId, paymentAction)
+    val customerRequestData = CustomerRequestDataFactory.build(clientId, redirectUri, paymentActions)
     val createCustomerRequest = CreateCustomerRequest(
       idempotencyKey = UUID.randomUUID().toString(),
       customerRequestData = customerRequestData,
     )
 
     // Record analytics.
-    analyticsEventDispatcher?.createdCustomerRequest(paymentAction, customerRequestData.actions.first())
+    analyticsEventDispatcher?.createdCustomerRequest(paymentActions, customerRequestData.actions, redirectUri)
 
     return executeNetworkRequest(
       POST,
@@ -101,16 +102,16 @@ internal class NetworkManagerImpl(
   override fun updateCustomerRequest(
     clientId: String,
     requestId: String,
-    paymentAction: CashAppPayPaymentAction,
+    paymentActions: List<CashAppPayPaymentAction>,
   ): NetworkResult<CustomerTopLevelResponse> {
     val customerRequestData =
-      CustomerRequestDataFactory.build(clientId, paymentAction, isRequestUpdate = true)
+      CustomerRequestDataFactory.build(clientId, null, paymentActions, isRequestUpdate = true)
     val createCustomerRequest = CreateCustomerRequest(
       customerRequestData = customerRequestData,
     )
 
     // Record analytics.
-    analyticsEventDispatcher?.updatedCustomerRequest(requestId, paymentAction, customerRequestData.actions.first())
+    analyticsEventDispatcher?.updatedCustomerRequest(requestId, paymentActions, customerRequestData.actions)
 
     return executeNetworkRequest(
       PATCH,

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -78,7 +78,7 @@ internal class NetworkManagerImpl(
   @Throws(IOException::class)
   override fun createCustomerRequest(
     clientId: String,
-    redirectUri: String,
+    redirectUri: String?,
     paymentActions: List<CashAppPayPaymentAction>,
   ): NetworkResult<CustomerTopLevelResponse> {
     val customerRequestData = CustomerRequestDataFactory.build(clientId, redirectUri, paymentActions)

--- a/core/src/main/java/app/cash/paykit/core/models/sdk/CashAppPayPaymentAction.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/sdk/CashAppPayPaymentAction.kt
@@ -20,7 +20,7 @@ import app.cash.paykit.core.CashAppPay
 /**
  * This class holds the information necessary for [CashAppPay.createCustomerRequest] to be executed.
  */
-sealed class CashAppPayPaymentAction(redirectUri: String, scopeId: String?) {
+sealed class CashAppPayPaymentAction(scopeId: String?) {
 
   /**
    * Describes an intent for a client to charge a customer a given amount.
@@ -31,30 +31,26 @@ sealed class CashAppPayPaymentAction(redirectUri: String, scopeId: String?) {
    *  - If no amount is provided to the action, the payment charged may be any amount (use this for tipping support).
    *  - If amount is provided, currency must be provided too (and vice versa).
    *
-   * @param redirectUri The URI for Cash App to redirect back to your app.
    * @param currency The type of currency to use for this payment.
    * @param amount Amount for this payment (typically in cents or equivalent monetary unit).
    * @param scopeId This is analogous with the reference ID, an optional field required for brands and merchants support. If null, client ID will be used instead.
    */
   data class OneTimeAction(
-    val redirectUri: String,
     val currency: CashAppPayCurrency?,
     val amount: Int?,
     val scopeId: String? = null,
-  ) : CashAppPayPaymentAction(redirectUri, scopeId)
+  ) : CashAppPayPaymentAction(scopeId)
 
   /**
    * Describes an intent for a client to store a customer's account, allowing a client to create payments
    * or issue refunds for it on a recurring basis.
    *
-   * @param redirectUri The URI for Cash App to redirect back to your app.
    * @param scopeId This is analogous with the reference ID, an optional field required for brands and merchants support. If null, client ID will be used instead.
    * @param accountReferenceId Identifier of the account or customer associated to the on file action.
    */
   data class OnFileAction(
-    val redirectUri: String,
     val scopeId: String? = null,
     val accountReferenceId: String? = null,
   ) :
-    CashAppPayPaymentAction(redirectUri, scopeId)
+    CashAppPayPaymentAction(scopeId)
 }

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayAuthorizeTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayAuthorizeTests.kt
@@ -15,26 +15,14 @@
  */
 package app.cash.paykit.core
 
-import android.content.Context
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import app.cash.paykit.core.models.response.CustomerResponseData
-import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import org.junit.Before
 import org.junit.Test
 
 class CashAppPayAuthorizeTests {
-
-  @MockK(relaxed = true)
-  private lateinit var context: Context
-
-  @Before
-  fun setup() {
-    MockKAnnotations.init(this)
-  }
 
   @Test(expected = CashAppPayIntegrationException::class)
   fun `should throw if calling authorize before createCustomer`() {

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
@@ -38,7 +38,7 @@ class CashAppPayExceptionsTests {
   @Test(expected = CashAppPayIntegrationException::class)
   fun `should throw on createCustomerRequest if has NOT registered for state updates`() {
     val payKit = createPayKit(useSandboxEnvironment = true)
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
   }
 
   @Test(expected = CashAppPayIntegrationException::class)
@@ -46,7 +46,7 @@ class CashAppPayExceptionsTests {
     val payKit = createPayKit(useSandboxEnvironment = true)
     val listener = mockk<CashAppPayListener>(relaxed = true)
     payKit.registerForStateUpdates(listener)
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, emptyList())
+    payKit.createCustomerRequest(emptyList(), FakeData.REDIRECT_URI)
   }
 
   @Test
@@ -58,7 +58,7 @@ class CashAppPayExceptionsTests {
     every { networkManager.createCustomerRequest(any(), any(), any()) } returns NetworkResult.failure(
       Exception("bad"),
     )
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
   }
 
   private fun createPayKit(useSandboxEnvironment: Boolean) =

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
@@ -38,7 +38,7 @@ class CashAppPayExceptionsTests {
   @Test(expected = CashAppPayIntegrationException::class)
   fun `should throw on createCustomerRequest if has NOT registered for state updates`() {
     val payKit = createPayKit(useSandboxEnvironment = true)
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
   }
 
   @Test
@@ -47,10 +47,10 @@ class CashAppPayExceptionsTests {
     val listener = mockk<CashAppPayListener>(relaxed = true)
     payKit.registerForStateUpdates(listener)
 
-    every { networkManager.createCustomerRequest(any(), any()) } returns NetworkResult.failure(
+    every { networkManager.createCustomerRequest(any(), any(), any()) } returns NetworkResult.failure(
       Exception("bad"),
     )
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
   }
 
   private fun createPayKit(useSandboxEnvironment: Boolean) =

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
@@ -72,11 +72,11 @@ class CashAppPayStateTests {
     val listener = mockk<CashAppPayListener>(relaxed = true)
     payKit.registerForStateUpdates(listener)
 
-    every { networkManager.createCustomerRequest(any(), any()) } returns NetworkResult.failure(
+    every { networkManager.createCustomerRequest(any(), any(), any()) } returns NetworkResult.failure(
       Exception("bad"),
     )
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
     verify { listener.cashAppPayStateDidChange(CreatingCustomerRequest) }
   }
 
@@ -120,10 +120,11 @@ class CashAppPayStateTests {
       networkManager.createCustomerRequest(
         any(),
         any(),
+        any(),
       )
     } returns customerTopLevelResponse
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
     verify { listener.cashAppPayStateDidChange(ofType(ReadyToAuthorize::class)) }
   }
 

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
@@ -76,7 +76,7 @@ class CashAppPayStateTests {
       Exception("bad"),
     )
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
     verify { listener.cashAppPayStateDidChange(CreatingCustomerRequest) }
   }
 
@@ -124,7 +124,7 @@ class CashAppPayStateTests {
       )
     } returns customerTopLevelResponse
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
     verify { listener.cashAppPayStateDidChange(ofType(ReadyToAuthorize::class)) }
   }
 
@@ -246,10 +246,6 @@ class CashAppPayStateTests {
 
     fun simulateOnApplicationForegrounded() {
       listener?.onApplicationForegrounded()
-    }
-
-    fun simulateOnApplicationBackgrounded() {
-      listener?.onApplicationBackgrounded()
     }
 
     override fun register(newInstance: CashAppPayLifecycleListener) {

--- a/core/src/test/java/app/cash/paykit/core/FakeData.kt
+++ b/core/src/test/java/app/cash/paykit/core/FakeData.kt
@@ -24,7 +24,7 @@ object FakeData {
   const val REDIRECT_URI = "fake_redirect_uri"
   const val FAKE_AMOUNT = 500
 
-  val oneTimePayment = OneTimeAction(REDIRECT_URI, USD, FAKE_AMOUNT, BRAND_ID)
+  val oneTimePayment = OneTimeAction(USD, FAKE_AMOUNT, BRAND_ID)
 
   val validCreateCustomerJSONresponse = """{
          "request":{

--- a/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
@@ -61,7 +61,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // Verify that all the appropriate exception wrapping has occurred for a 503 error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)
@@ -101,7 +101,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // Verify that all the appropriate exception wrapping has occurred for a 400 error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)
@@ -140,7 +140,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // Verify that a timeout error was captured and relayed to the SDK listener.
     assertThat(((mockListener.state as CashAppPayExceptionState).exception as CashAppPayConnectivityNetworkException).e).isInstanceOf(
@@ -199,7 +199,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // Verify that we got the appropriate JSON deserialization error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)

--- a/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
@@ -61,7 +61,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // Verify that all the appropriate exception wrapping has occurred for a 503 error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)
@@ -101,7 +101,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // Verify that all the appropriate exception wrapping has occurred for a 400 error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)
@@ -140,7 +140,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // Verify that a timeout error was captured and relayed to the SDK listener.
     assertThat(((mockListener.state as CashAppPayExceptionState).exception as CashAppPayConnectivityNetworkException).e).isInstanceOf(
@@ -199,7 +199,7 @@ class NetworkErrorTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // Verify that we got the appropriate JSON deserialization error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)

--- a/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
@@ -59,7 +59,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // If retry has happened, we got to a `ReadyToAuthorize` state.
     assertThat(mockListener.state).isInstanceOf(ReadyToAuthorize::class.java)
@@ -91,7 +91,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // We should retry twice, and then stop retrying. If the number of retries is correct,
     // we should have reached a `PayKitException` and NOT a `ReadyToAuthorize` state.
@@ -127,7 +127,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // If retry has happened, we got to a `ReadyToAuthorize` state.
     assertThat(mockListener.state).isInstanceOf(ReadyToAuthorize::class.java)
@@ -162,7 +162,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.oneTimePayment, FakeData.REDIRECT_URI)
 
     // Verify that a timeout error was captured and relayed to the SDK listener.
     assertThat(((mockListener.state as CashAppPayExceptionState).exception as CashAppPayConnectivityNetworkException).e).isInstanceOf(

--- a/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
@@ -59,7 +59,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // If retry has happened, we got to a `ReadyToAuthorize` state.
     assertThat(mockListener.state).isInstanceOf(ReadyToAuthorize::class.java)
@@ -91,7 +91,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // We should retry twice, and then stop retrying. If the number of retries is correct,
     // we should have reached a `PayKitException` and NOT a `ReadyToAuthorize` state.
@@ -127,7 +127,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // If retry has happened, we got to a `ReadyToAuthorize` state.
     assertThat(mockListener.state).isInstanceOf(ReadyToAuthorize::class.java)
@@ -162,7 +162,7 @@ class NetworkRetryTests {
     val mockListener = MockListener()
     payKit.registerForStateUpdates(mockListener)
 
-    payKit.createCustomerRequest(FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
 
     // Verify that a timeout error was captured and relayed to the SDK listener.
     assertThat(((mockListener.state as CashAppPayExceptionState).exception as CashAppPayConnectivityNetworkException).e).isInstanceOf(

--- a/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
+++ b/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
@@ -15,17 +15,14 @@
  */
 package app.cash.paykit.core
 
-import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
-import app.cash.paykit.core.models.common.NetworkResult
 import io.mockk.MockKAnnotations
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Test
 
-class CashAppPayExceptionsTests {
+class CashAppPayProdExceptionsTests {
 
   @MockK(relaxed = true)
   private lateinit var networkManager: NetworkManager
@@ -35,30 +32,12 @@ class CashAppPayExceptionsTests {
     MockKAnnotations.init(this)
   }
 
-  @Test(expected = CashAppPayIntegrationException::class)
-  fun `should throw on createCustomerRequest if has NOT registered for state updates`() {
-    val payKit = createPayKit(useSandboxEnvironment = true)
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
-  }
-
-  @Test(expected = CashAppPayIntegrationException::class)
-  fun `should throw during Dev when paymentActions is an empty list`() {
-    val payKit = createPayKit(useSandboxEnvironment = true)
-    val listener = mockk<CashAppPayListener>(relaxed = true)
-    payKit.registerForStateUpdates(listener)
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, emptyList())
-  }
-
   @Test
-  fun `logAndSoftCrash should NOT crash in prod`() {
+  fun `softCrashOrStateException should NOT crash in prod`() {
     val payKit = createPayKit(useSandboxEnvironment = false)
     val listener = mockk<CashAppPayListener>(relaxed = true)
     payKit.registerForStateUpdates(listener)
-
-    every { networkManager.createCustomerRequest(any(), any(), any()) } returns NetworkResult.failure(
-      Exception("bad"),
-    )
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, FakeData.oneTimePayment)
+    payKit.createCustomerRequest(FakeData.REDIRECT_URI, emptyList())
   }
 
   private fun createPayKit(useSandboxEnvironment: Boolean) =

--- a/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
+++ b/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
@@ -37,7 +37,7 @@ class CashAppPayProdExceptionsTests {
     val payKit = createPayKit(useSandboxEnvironment = false)
     val listener = mockk<CashAppPayListener>(relaxed = true)
     payKit.registerForStateUpdates(listener)
-    payKit.createCustomerRequest(FakeData.REDIRECT_URI, emptyList())
+    payKit.createCustomerRequest(emptyList(), FakeData.REDIRECT_URI)
   }
 
   private fun createPayKit(useSandboxEnvironment: Boolean) =


### PR DESCRIPTION
Our API supports multiple actions on a single customer request, but the CAP interface only exposed a single action. This PR updates the interface to support multiple actions.

**Notable changes**
 - `CashAppPay` interface now supports 2 overloaded versions of `createCustomerRequest` and `updateCustomerRequest` . The difference is that one supports a a single `CashAppPayPaymentAction` _vs_ a list of them.
 - The single `CashAppPayPaymentAction` was kept since this is the most likely option for most merchants to integrate with
 - Analytics was updated to support this change. When multiple actions are contained within a single customer request, a separate analytics event is issued per action
 - Added a verification to check that the "list of actions" isn't empty. In case it is empty, it will crash during development and produce an SDK state exception otherwise.


## Verification

This video showcases a create customer request that has both one-time and on-file payments on the same request:

https://user-images.githubusercontent.com/416941/229634697-d1a21fdb-76cf-4700-a213-3255a91990e0.mp4


