### PR TITLE
Fix Retrieve Existing request ID behavior for PROCESSING state

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -197,7 +197,7 @@ internal class CashAppCashAppPayImpl(
         // Determine what kind of status we got.
         currentState = when (customerResponseData?.status) {
           STATUS_PENDING -> {
-            ReadyToAuthorize(networkResult.data.customerResponseData)
+            Authorizing
           }
 
           STATUS_APPROVED -> {
@@ -208,6 +208,8 @@ internal class CashAppCashAppPayImpl(
             Declined
           }
         }
+
+        updateStateAndPoolForTransactionStatus()
       }
     }
   }
@@ -360,16 +362,20 @@ internal class CashAppCashAppPayImpl(
     }
   }
 
+  private fun updateStateAndPoolForTransactionStatus() {
+    if (currentState is Authorizing) {
+      currentState = PollingTransactionStatus
+      poolTransactionStatus()
+    }
+  }
+
   /**
    * Lifecycle callbacks.
    */
 
   override fun onApplicationForegrounded() {
     logError("onApplicationForegrounded")
-    if (currentState is Authorizing) {
-      currentState = PollingTransactionStatus
-      poolTransactionStatus()
-    }
+    updateStateAndPoolForTransactionStatus()
   }
 
   override fun onApplicationBackgrounded() {

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -44,6 +44,7 @@ import app.cash.paykit.core.models.common.NetworkResult.Success
 import app.cash.paykit.core.models.response.CustomerResponseData
 import app.cash.paykit.core.models.response.STATUS_APPROVED
 import app.cash.paykit.core.models.response.STATUS_PENDING
+import app.cash.paykit.core.models.response.STATUS_PROCESSING
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction
 import app.cash.paykit.core.utils.orElse
 
@@ -196,8 +197,12 @@ internal class CashAppCashAppPayImpl(
 
         // Determine what kind of status we got.
         currentState = when (customerResponseData?.status) {
-          STATUS_PENDING -> {
+          STATUS_PROCESSING -> {
             Authorizing
+          }
+
+          STATUS_PENDING -> {
+            ReadyToAuthorize(customerResponseData!!)
           }
 
           STATUS_APPROVED -> {

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
@@ -20,7 +20,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 const val STATUS_PENDING = "PENDING"
+const val STATUS_PROCESSING = "PROCESSING"
 const val STATUS_APPROVED = "APPROVED"
+const val STATUS_DECLINED = "DECLINED"
 
 @JsonClass(generateAdapter = true)
 data class CustomerResponseData(

--- a/core/src/test/java/app/cash/paykit/core/FakeData.kt
+++ b/core/src/test/java/app/cash/paykit/core/FakeData.kt
@@ -23,6 +23,7 @@ object FakeData {
   const val BRAND_ID = "fake_brand_id"
   const val REDIRECT_URI = "fake_redirect_uri"
   const val FAKE_AMOUNT = 500
+  const val REQUEST_ID = "Request-id-fake-123"
 
   val oneTimePayment = OneTimeAction(USD, FAKE_AMOUNT, BRAND_ID)
 


### PR DESCRIPTION
When retrieving an existing customer request, a `PROCESSING` status should resulting into a long-polling operation that will continuously check for status update from the backend.

Add further Unit Tests for `startWithExistingCustomerRequest`.