### PR TITLE
OkHttp 3 & Moshi 3.12.0 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     mockwebserver_version = '4.10.0'
     google_truth_version = '1.1.3'
     startup_version = '1.1.1'
-    okhttp_version = '4.10.0'
+    okhttp_version = '3.14.9'
 
     versions = [
         'minSdk': 21,
@@ -50,11 +50,11 @@ subprojects { subproject ->
     }
   }
 }
-def NEXT_VERSION = "2.0.1-SNAPSHOT"
+def NEXT_VERSION = "2.0.2-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '2.0.0'
+  version = '2.0.1'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   ext {
     junit_androidx_version = '1.1.5'
     junit_version = '4.13.2'
-    moshi_version = '1.13.0'
+    moshi_version = '1.12.0'
     lifecycle_version = '2.5.1'
     mockk_version = '1.13.3'
     coroutines_test_version = '1.6.4'
@@ -50,11 +50,11 @@ subprojects { subproject ->
     }
   }
 }
-def NEXT_VERSION = "2.0.2-SNAPSHOT"
+def NEXT_VERSION = "2.0.3-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '2.0.1-SNAPSHOT'
+  version = '2.0.2-SNAPSHOT'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ def NEXT_VERSION = "2.0.2-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '2.0.1'
+  version = '2.0.1-SNAPSHOT'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,8 +5,6 @@ plugins {
   id "com.vanniktech.maven.publish.base"
 }
 
-apply plugin: 'kotlin-kapt'
-
 task sourceJar(type: Jar) {
   from android.sourceSets.main.java.srcDirs
   classifier "sources"
@@ -58,10 +56,6 @@ android {
       includeAndroidResources = true
     }
   }
-}
-
-kapt {
-  useBuildCache = false
 }
 
 dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,10 +1,11 @@
 plugins {
   id 'com.android.library'
   id 'org.jetbrains.kotlin.android'
-  id("com.google.devtools.ksp").version("1.6.21-1.0.5")
   id 'project-report' // run ./gradlew htmlDependencyReport
   id "com.vanniktech.maven.publish.base"
 }
+
+apply plugin: 'kotlin-kapt'
 
 task sourceJar(type: Jar) {
   from android.sourceSets.main.java.srcDirs
@@ -59,11 +60,12 @@ android {
   }
 }
 
+kapt {
+  useBuildCache = false
+}
+
 dependencies {
 
-  // We want to lock this dependency at a lower than latest version to not force transitive updates onto merchants.
-  //noinspection GradleDependency
-  ksp("com.squareup.moshi:moshi-kotlin-codegen:$moshi_version")
   //noinspection GradleDependency
   implementation("com.squareup.moshi:moshi-kotlin:$moshi_version")
 

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -49,6 +49,7 @@ import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction.OnFileAction
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.*
 
 private const val APP_NAME = "paykitsdk-android"
@@ -62,7 +63,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   private val sdkEnvironment: String,
   private val payKitAnalytics: PayKitAnalytics,
   private val networkManager: NetworkManager,
-  private val moshi: Moshi = Moshi.Builder().build(),
+  private val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
 ) : PayKitAnalyticsEventDispatcher {
 
   private var eventStreamDeliverHandler: DeliveryHandler? = null

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -38,6 +38,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonEncodingException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -159,7 +160,7 @@ internal class NetworkManagerImpl(
     clientId: String,
     requestPayload: In?,
   ): NetworkResult<Out> {
-    val moshi: Moshi = Moshi.Builder().build()
+    val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
     val requestJsonAdapter: JsonAdapter<In> = moshi.adapter()
     val jsonData: String = requestJsonAdapter.toJson(requestPayload)
     return executePlainNetworkRequest(
@@ -197,7 +198,7 @@ internal class NetworkManagerImpl(
       requestBuilder.addHeader("Authorization", "Client $clientId")
     }
 
-    val moshi: Moshi = Moshi.Builder().build()
+    val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
 
     with(requestBuilder) {
       when (requestType) {


### PR DESCRIPTION
PR that downgrades OkHttp and Moshi versions for compatibility with merchants with older codebase.

Some notes about Moshi:

 * Switched to using Reflection over Generated sources, since `kapt` was giving me a weird error. There might be some performance degradation from this change, but honestly the payloads are so small that might not be noticeable. Plus as a one-off that has a deadline, it seems more urgent to prioritize getting this shipped.

# Verification

Happy path is working as expected, so can deduce that Moshi downgrade was successful for the most part.


https://user-images.githubusercontent.com/416941/233695418-7b1b12f8-e794-46f4-9be5-602fd9da5502.mp4

