### PR TITLE
Add UT for Analytics

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -46,11 +46,14 @@ import app.cash.paykit.core.models.response.CustomerResponseData
 import app.cash.paykit.core.models.response.Grant
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction.OnFileAction
+import app.cash.paykit.core.utils.Clock
+import app.cash.paykit.core.utils.ClockRealImpl
+import app.cash.paykit.core.utils.UUIDManager
+import app.cash.paykit.core.utils.UUIDManagerRealImpl
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import java.util.*
-import java.util.concurrent.TimeUnit
 
 private const val APP_NAME = "paykitsdk-android"
 private const val PLATFORM = "android"
@@ -64,6 +67,8 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   private val payKitAnalytics: PayKitAnalytics,
   private val networkManager: NetworkManager,
   private val moshi: Moshi = Moshi.Builder().build(),
+  private val uuidManager: UUIDManager = UUIDManagerRealImpl(),
+  private val clock: Clock = ClockRealImpl(),
 ) : PayKitAnalyticsEventDispatcher {
 
   private var eventStreamDeliverHandler: DeliveryHandler? = null
@@ -245,9 +250,9 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       EventStream2Event(
         appName = APP_NAME,
         catalogName = catalog,
-        uuid = UUID.randomUUID().toString(),
+        uuid = uuidManager.generateUUID(),
         jsonData = jsonData,
-        recordedAt = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()),
+        recordedAt = clock.currentTimeInMicroseconds(),
       )
 
     // Transform ES2 event into a JSON String.

--- a/core/src/main/java/app/cash/paykit/core/utils/Clock.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/Clock.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+internal interface Clock {
+  /**
+   * Returns the current Epoch time in microseconds (AKA usec).
+   */
+  fun currentTimeInMicroseconds(): Long
+}

--- a/core/src/main/java/app/cash/paykit/core/utils/ClockRealImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/ClockRealImpl.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+import java.util.concurrent.TimeUnit
+
+internal class ClockRealImpl : Clock {
+  override fun currentTimeInMicroseconds(): Long {
+    return TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis())
+  }
+}

--- a/core/src/main/java/app/cash/paykit/core/utils/UUIDManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/UUIDManager.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+internal interface UUIDManager {
+
+  /**
+   * Returns a UUID as a String.
+   */
+  fun generateUUID(): String
+}

--- a/core/src/main/java/app/cash/paykit/core/utils/UUIDManagerRealImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/UUIDManagerRealImpl.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+import java.util.UUID
+
+internal class UUIDManagerRealImpl : UUIDManager {
+  override fun generateUUID(): String {
+    return UUID.randomUUID().toString()
+  }
+}

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayAuthorizeTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayAuthorizeTests.kt
@@ -16,6 +16,7 @@
 package app.cash.paykit.core
 
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
+import app.cash.paykit.core.fakes.FakeData
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import app.cash.paykit.core.models.response.CustomerResponseData
 import io.mockk.every

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
@@ -16,6 +16,7 @@
 package app.cash.paykit.core
 
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
+import app.cash.paykit.core.fakes.FakeData
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import app.cash.paykit.core.models.common.NetworkResult
 import io.mockk.MockKAnnotations

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
@@ -27,6 +27,7 @@ import app.cash.paykit.core.CashAppPayState.PollingTransactionStatus
 import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
 import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.android.ApplicationContextHolder
+import app.cash.paykit.core.fakes.FakeData
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import app.cash.paykit.core.impl.CashAppPayLifecycleListener
 import app.cash.paykit.core.models.common.NetworkResult

--- a/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
@@ -18,6 +18,7 @@ package app.cash.paykit.core
 import app.cash.paykit.core.CashAppPayState.CashAppPayExceptionState
 import app.cash.paykit.core.exceptions.CashAppCashAppPayApiNetworkException
 import app.cash.paykit.core.exceptions.CashAppPayConnectivityNetworkException
+import app.cash.paykit.core.fakes.FakeData
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import app.cash.paykit.core.impl.NetworkManagerImpl
 import app.cash.paykit.core.network.RetryManagerOptions

--- a/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
@@ -19,6 +19,7 @@ import app.cash.paykit.core.CashAppPayState.CashAppPayExceptionState
 import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
 import app.cash.paykit.core.NetworkErrorTests.MockListener
 import app.cash.paykit.core.exceptions.CashAppPayConnectivityNetworkException
+import app.cash.paykit.core.fakes.FakeData
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import app.cash.paykit.core.impl.NetworkManagerImpl
 import app.cash.paykit.core.network.RetryManagerOptions

--- a/core/src/test/java/app/cash/paykit/core/PayKitAnalyticsEventDispatcherImplTest.kt
+++ b/core/src/test/java/app/cash/paykit/core/PayKitAnalyticsEventDispatcherImplTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core
+
+import app.cash.paykit.analytics.PayKitAnalytics
+import app.cash.paykit.core.analytics.AnalyticsEventStream2Event
+import app.cash.paykit.core.analytics.PayKitAnalyticsEventDispatcherImpl
+import app.cash.paykit.core.fakes.FakeClock
+import app.cash.paykit.core.fakes.FakeData
+import app.cash.paykit.core.fakes.FakeUUIDManager
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class PayKitAnalyticsEventDispatcherImplTest {
+
+  @MockK(relaxed = true)
+  private lateinit var networkManager: NetworkManager
+
+  @MockK(relaxed = true)
+  private lateinit var paykitAnalytics: PayKitAnalytics
+
+  @Before
+  fun setup() {
+    MockKAnnotations.init(this)
+  }
+
+  @Test
+  fun `sdkInitialized records valid analytics event`() {
+    val analyticsDispatcher = buildDispatcher()
+    analyticsDispatcher.sdkInitialized()
+    val contents = """{"app_name":"paykitsdk-android","catalog_name":"mobile_cap_pk_initialization","json_data":"{\"mobile_cap_pk_initialization_sdk_version\":\"1.0.0\",\"mobile_cap_pk_initialization_client_ua\":\"Webkit/1.0.0 (Linux; U; Android 12; en-US; Samsung Build/XYZ)\",\"mobile_cap_pk_initialization_platform\":\"android\",\"mobile_cap_pk_initialization_client_id\":\"fake_client_id\",\"mobile_cap_pk_initialization_environment\":\"SANDBOX\"}","recorded_at_usec":123,"uuid":"abc"}"""
+
+    verify { paykitAnalytics.scheduleForDelivery(AnalyticsEventStream2Event(contents)) }
+  }
+
+  @Test
+  fun `eventListenerAdded records valid analytics event`() {
+    val analyticsDispatcher = buildDispatcher()
+    analyticsDispatcher.eventListenerAdded()
+    val contents = """{"app_name":"paykitsdk-android","catalog_name":"mobile_cap_pk_event_listener","json_data":"{\"mobile_cap_pk_event_listener_sdk_version\":\"1.0.0\",\"mobile_cap_pk_event_listener_client_ua\":\"Webkit/1.0.0 (Linux; U; Android 12; en-US; Samsung Build/XYZ)\",\"mobile_cap_pk_event_listener_platform\":\"android\",\"mobile_cap_pk_event_listener_client_id\":\"fake_client_id\",\"mobile_cap_pk_event_listener_environment\":\"SANDBOX\",\"mobile_cap_pk_event_listener_is_added\":true}","recorded_at_usec":123,"uuid":"abc"}"""
+
+    verify { paykitAnalytics.scheduleForDelivery(AnalyticsEventStream2Event(contents)) }
+  }
+
+  @Test
+  fun `eventListenerRemoved records valid analytics event`() {
+    val analyticsDispatcher = buildDispatcher()
+    analyticsDispatcher.eventListenerRemoved()
+    val contents = """{"app_name":"paykitsdk-android","catalog_name":"mobile_cap_pk_event_listener","json_data":"{\"mobile_cap_pk_event_listener_sdk_version\":\"1.0.0\",\"mobile_cap_pk_event_listener_client_ua\":\"Webkit/1.0.0 (Linux; U; Android 12; en-US; Samsung Build/XYZ)\",\"mobile_cap_pk_event_listener_platform\":\"android\",\"mobile_cap_pk_event_listener_client_id\":\"fake_client_id\",\"mobile_cap_pk_event_listener_environment\":\"SANDBOX\",\"mobile_cap_pk_event_listener_is_added\":false}","recorded_at_usec":123,"uuid":"abc"}"""
+
+    verify { paykitAnalytics.scheduleForDelivery(AnalyticsEventStream2Event(contents)) }
+  }
+
+  @Test
+  fun `SDK state update records valid analytics event`() {
+    val analyticsDispatcher = buildDispatcher()
+    analyticsDispatcher.genericStateChanged(CashAppPayState.Authorizing, null)
+    val contents = """{"app_name":"paykitsdk-android","catalog_name":"mobile_cap_pk_customer_request","json_data":"{\"mobile_cap_pk_customer_request_sdk_version\":\"1.0.0\",\"mobile_cap_pk_customer_request_client_ua\":\"Webkit/1.0.0 (Linux; U; Android 12; en-US; Samsung Build/XYZ)\",\"mobile_cap_pk_customer_request_platform\":\"android\",\"mobile_cap_pk_customer_request_client_id\":\"fake_client_id\",\"mobile_cap_pk_customer_request_environment\":\"SANDBOX\",\"mobile_cap_pk_customer_request_action\":\"redirect\",\"mobile_cap_pk_customer_request_channel\":\"IN_APP\"}","recorded_at_usec":123,"uuid":"abc"}"""
+
+    verify { paykitAnalytics.scheduleForDelivery(AnalyticsEventStream2Event(contents)) }
+  }
+
+  private fun buildDispatcher() = PayKitAnalyticsEventDispatcherImpl(
+    FakeData.SDK_VERSION,
+    FakeData.CLIENT_ID,
+    FakeData.USER_AGENT,
+    FakeData.SDK_ENVIRONMENT_SANDBOX,
+    paykitAnalytics,
+    networkManager,
+    uuidManager = FakeUUIDManager(),
+    clock = FakeClock(),
+  )
+}

--- a/core/src/test/java/app/cash/paykit/core/fakes/FakeClock.kt
+++ b/core/src/test/java/app/cash/paykit/core/fakes/FakeClock.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.fakes
+
+import app.cash.paykit.core.utils.Clock
+
+class FakeClock : Clock {
+  companion object {
+    const val NOW = 123L
+  }
+
+  override fun currentTimeInMicroseconds(): Long {
+    return NOW
+  }
+}

--- a/core/src/test/java/app/cash/paykit/core/fakes/FakeData.kt
+++ b/core/src/test/java/app/cash/paykit/core/fakes/FakeData.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.paykit.core
+package app.cash.paykit.core.fakes
 
 import app.cash.paykit.core.models.sdk.CashAppPayCurrency.USD
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction.OneTimeAction
@@ -24,6 +24,10 @@ object FakeData {
   const val REDIRECT_URI = "fake_redirect_uri"
   const val FAKE_AMOUNT = 500
   const val REQUEST_ID = "Request-id-fake-123"
+
+  const val SDK_VERSION = "1.0.0"
+  const val USER_AGENT = "Webkit/1.0.0 (Linux; U; Android 12; en-US; Samsung Build/XYZ)"
+  const val SDK_ENVIRONMENT_SANDBOX = "SANDBOX"
 
   val oneTimePayment = OneTimeAction(USD, FAKE_AMOUNT, BRAND_ID)
 

--- a/core/src/test/java/app/cash/paykit/core/fakes/FakeUUIDManager.kt
+++ b/core/src/test/java/app/cash/paykit/core/fakes/FakeUUIDManager.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.fakes
+
+import app.cash.paykit.core.utils.UUIDManager
+
+class FakeUUIDManager : UUIDManager {
+
+  companion object {
+    const val UUID = "abc"
+  }
+  override fun generateUUID(): String {
+    return UUID
+  }
+}

--- a/core/src/test/java/app/cash/paykit/core/utils/ClockTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/utils/ClockTests.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ClockTests {
+
+  @Test
+  fun `currentTimeInMicroseconds should return current time in microseconds`() {
+    val clock = ClockRealImpl()
+    val currentTimeInMicroseconds = clock.currentTimeInMicroseconds()
+    assertThat(currentTimeInMicroseconds).isGreaterThan(0)
+
+    // Microseconds of when the test was written.
+    assertThat(currentTimeInMicroseconds).isAtLeast(1686318558468000)
+  }
+}

--- a/core/src/test/java/app/cash/paykit/core/utils/UUIDTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/utils/UUIDTests.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class UUIDTests {
+  @Test
+  fun `generateUUID should return a different valid UUID each time`() {
+    val uuidManager = UUIDManagerRealImpl()
+    val uuid = uuidManager.generateUUID()
+    assertThat(uuid).isNotEmpty()
+    assertThat(uuid).hasLength(36)
+    val secondUuid = uuidManager.generateUUID()
+    assertThat(secondUuid).isNotEqualTo(uuid)
+  }
+}

--- a/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
+++ b/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paykit.core
 
+import app.cash.paykit.core.fakes.FakeData
 import app.cash.paykit.core.impl.CashAppCashAppPayImpl
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK


### PR DESCRIPTION
This PR adds a few Unit Tests to validate that Analytics payloads contain the expected information. They're not very elaborate, but serve to at a minimum protect us against any future breaking.

As part of this work, I made an interface for `Clock` and `UUID`, so these two things could be easily faked to output predictable values.