### PR TITLE
Refresh Auth Token for Customer Request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     google_truth_version = '1.1.3'
     startup_version = '1.1.1'
     okhttp_version = '4.10.0'
+    kotlinx_date_version = '0.4.0'
 
     versions = [
         'minSdk': 21,

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,6 +67,9 @@ dependencies {
   //noinspection GradleDependency
   implementation("com.squareup.moshi:moshi-kotlin:$moshi_version")
 
+  // KotlinX Dates.
+  implementation "org.jetbrains.kotlinx:kotlinx-datetime:$kotlinx_date_version"
+
   // Provides a lifecycle for the whole application process.
   implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
 

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -250,6 +250,7 @@ object CashAppPayFactory {
   private val ANALYTICS_PROD_ENVIRONMENT = "production"
   private val ANALYTICS_SANDBOX_ENVIRONMENT = "sandbox"
 
+  // This is the threshold for when in advance of a token expiring we should refresh it.
   internal val TOKEN_REFRESH_WINDOW = 10.seconds
 }
 

--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -249,6 +249,8 @@ object CashAppPayFactory {
   private val ANALYTICS_DB_NAME_SANDBOX = "paykit-events-sandbox.db"
   private val ANALYTICS_PROD_ENVIRONMENT = "production"
   private val ANALYTICS_SANDBOX_ENVIRONMENT = "sandbox"
+
+  internal val TOKEN_REFRESH_WINDOW = 10.seconds
 }
 
 interface CashAppPayListener {

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayState.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayState.kt
@@ -60,6 +60,13 @@ sealed interface CashAppPayState {
   object Authorizing : CashAppPayState
 
   /**
+   * This state denotes that we're in the process of refreshing the existing customer request,
+   * in case the authorization has expired. This is typically an in-between between [Authorizing]
+   * and [PollingTransactionStatus].
+   */
+  object Refreshing : CashAppPayState
+
+  /**
    * This state denotes that we're actively polling for an authorization update. This state will
    * typically transition to either [Approved] or [Declined].
    */

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -28,6 +28,7 @@ import app.cash.paykit.core.CashAppPayState.Declined
 import app.cash.paykit.core.CashAppPayState.NotStarted
 import app.cash.paykit.core.CashAppPayState.PollingTransactionStatus
 import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
+import app.cash.paykit.core.CashAppPayState.Refreshing
 import app.cash.paykit.core.CashAppPayState.RetrievingExistingCustomerRequest
 import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.NetworkManager
@@ -295,6 +296,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
     return when (state) {
       is Approved -> "approved"
       Authorizing -> "redirect"
+      Refreshing -> "refreshing"
       CreatingCustomerRequest -> "create"
       Declined -> "declined"
       NotStarted -> "not_started"

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -46,6 +46,7 @@ import app.cash.paykit.core.models.response.CustomerResponseData
 import app.cash.paykit.core.models.response.Grant
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction.OnFileAction
+import app.cash.paykit.core.network.MoshiProvider
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
@@ -63,7 +64,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
   private val sdkEnvironment: String,
   private val payKitAnalytics: PayKitAnalytics,
   private val networkManager: NetworkManager,
-  private val moshi: Moshi = Moshi.Builder().build(),
+  private val moshi: Moshi = MoshiProvider.provideDefault(),
 ) : PayKitAnalyticsEventDispatcher {
 
   private var eventStreamDeliverHandler: DeliveryHandler? = null
@@ -269,8 +270,8 @@ internal class PayKitAnalyticsEventDispatcherImpl(
       clientId,
       status = customerResponseData?.status,
       authMobileUrl = customerResponseData?.authFlowTriggers?.mobileUrl,
-      updatedAt = customerResponseData?.updatedAt?.toLongOrNull(),
-      createdAt = customerResponseData?.createdAt?.toLongOrNull(),
+      updatedAt = customerResponseData?.updatedAt?.toEpochMilliseconds(),
+      createdAt = customerResponseData?.createdAt?.toEpochMilliseconds(),
       originType = customerResponseData?.origin?.type,
       originId = customerResponseData?.origin?.id,
       requestChannel = CHANNEL_IN_APP,

--- a/core/src/main/java/app/cash/paykit/core/android/LogTag.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/LogTag.kt
@@ -15,20 +15,4 @@
  */
 package app.cash.paykit.core.android
 
-import android.util.Log
-
-/**
- * This class is used to wrap a thread start operation in a way that allows for smooth degradation on exception, as well as convenient and consistent error handling.
- */
-fun Thread.safeStart(errorMessage: String?, onError: () -> Unit? = {}) {
-  try {
-    start()
-  } catch (e: IllegalThreadStateException) {
-    // This can happen if the thread is already started.
-    Log.e(LOG_TAG, errorMessage, e)
-    onError()
-  } catch (e: InterruptedException) {
-    Log.e(LOG_TAG, errorMessage, e)
-    onError()
-  }
-}
+const val LOG_TAG = "CashAppPay"

--- a/core/src/main/java/app/cash/paykit/core/android/ThreadExtensions.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/ThreadExtensions.kt
@@ -18,7 +18,7 @@ package app.cash.paykit.core.android
 import android.util.Log
 
 /**
- * This class is used to wrap a thread and allow it to be interrupted.
+ * This class is used to wrap a thread start operation in a way that allows for smooth degradation on exception, as well as convenient and consistent error handling.
  */
 fun Thread.safeStart(errorMessage: String?, onError: () -> Unit? = {}) {
   try {

--- a/core/src/main/java/app/cash/paykit/core/android/ThreadExtensions.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/ThreadExtensions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.android
+
+import android.util.Log
+
+/**
+ * This class is used to wrap a thread and allow it to be interrupted.
+ */
+fun Thread.safeStart(errorMessage: String?, onError: () -> Unit? = {}) {
+  try {
+    start()
+  } catch (e: IllegalThreadStateException) {
+    // This can happen if the thread is already started.
+    Log.e("CAP", errorMessage, e)
+    onError()
+  } catch (e: InterruptedException) {
+    Log.e("CAP", errorMessage, e)
+    onError()
+  }
+}

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -244,13 +244,6 @@ internal class CashAppCashAppPayImpl(
       return
     }
 
-    // Stop refreshing unauthorized customer request.
-    try {
-      refreshUnauthorizedThread?.interrupt()
-    } catch (e: Exception) {
-      logError("Error while interrupting threads. Exception: $e")
-    }
-
     authorizeCustomerRequest(customerData)
   }
 

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -210,6 +210,7 @@ internal class CashAppCashAppPayImpl(
           }
 
           STATUS_PENDING -> {
+            scheduleUnauthorizedCustomerRequestRefresh(networkResult.data.customerResponseData)
             ReadyToAuthorize(customerResponseData!!)
           }
 

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -31,6 +31,7 @@ import app.cash.paykit.core.models.request.CustomerRequestDataFactory
 import app.cash.paykit.core.models.response.ApiErrorResponse
 import app.cash.paykit.core.models.response.CustomerTopLevelResponse
 import app.cash.paykit.core.models.sdk.CashAppPayPaymentAction
+import app.cash.paykit.core.network.MoshiProvider
 import app.cash.paykit.core.network.RetryManager
 import app.cash.paykit.core.network.RetryManagerImpl
 import app.cash.paykit.core.network.RetryManagerOptions
@@ -159,7 +160,7 @@ internal class NetworkManagerImpl(
     clientId: String,
     requestPayload: In?,
   ): NetworkResult<Out> {
-    val moshi: Moshi = Moshi.Builder().build()
+    val moshi: Moshi = MoshiProvider.provideDefault()
     val requestJsonAdapter: JsonAdapter<In> = moshi.adapter()
     val jsonData: String = requestJsonAdapter.toJson(requestPayload)
     return executePlainNetworkRequest(
@@ -197,7 +198,7 @@ internal class NetworkManagerImpl(
       requestBuilder.addHeader("Authorization", "Client $clientId")
     }
 
-    val moshi: Moshi = Moshi.Builder().build()
+    val moshi: Moshi = MoshiProvider.provideDefault()
 
     with(requestBuilder) {
       when (requestType) {

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -223,7 +223,11 @@ internal class NetworkManagerImpl(
 
             // Wait until the next retry.
             if (retryManager.shouldRetry()) {
-              Thread.sleep(retryManager.timeUntilNextRetry().inWholeMilliseconds)
+              try {
+                Thread.sleep(retryManager.timeUntilNextRetry().inWholeMilliseconds)
+              } catch (e: InterruptedException) {
+                return NetworkResult.failure(CashAppPayConnectivityNetworkException(retryException))
+              }
             }
             return@use
           }
@@ -264,7 +268,11 @@ internal class NetworkManagerImpl(
 
         // Wait until the next retry.
         if (retryManager.shouldRetry()) {
-          Thread.sleep(retryManager.timeUntilNextRetry().inWholeMilliseconds)
+          try {
+            Thread.sleep(retryManager.timeUntilNextRetry().inWholeMilliseconds)
+          } catch (e: InterruptedException) {
+            return NetworkResult.failure(CashAppPayConnectivityNetworkException(retryException))
+          }
         }
         retryException = e
       }

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
@@ -18,6 +18,7 @@ package app.cash.paykit.core.models.response
 import app.cash.paykit.core.models.common.Action
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlinx.datetime.Instant
 
 const val STATUS_PENDING = "PENDING"
 const val STATUS_PROCESSING = "PROCESSING"
@@ -41,11 +42,11 @@ data class CustomerResponseData(
   @Json(name = "status")
   val status: String,
   @Json(name = "updated_at")
-  val updatedAt: String,
+  val updatedAt: Instant,
   @Json(name = "created_at")
-  val createdAt: String,
+  val createdAt: Instant,
   @Json(name = "expires_at")
-  val expiresAt: String,
+  val expiresAt: Instant,
   @Json(name = "customer_profile")
   val customerProfile: CustomerProfile?,
   @Json(name = "grants")

--- a/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
+++ b/core/src/main/java/app/cash/paykit/core/models/response/CustomerResponseData.kt
@@ -18,6 +18,7 @@ package app.cash.paykit.core.models.response
 import app.cash.paykit.core.models.common.Action
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlinx.datetime.Clock.System
 import kotlinx.datetime.Instant
 
 const val STATUS_PENDING = "PENDING"
@@ -53,4 +54,10 @@ data class CustomerResponseData(
   val grants: List<Grant>?,
   @Json(name = "reference_id")
   val referenceId: String?,
-)
+) {
+  fun isAuthTokenExpired(): Boolean {
+    val now = System.now()
+    val isExpired = now > (authFlowTriggers?.refreshesAt ?: return false)
+    return isExpired
+  }
+}

--- a/core/src/main/java/app/cash/paykit/core/network/MoshiProvider.kt
+++ b/core/src/main/java/app/cash/paykit/core/network/MoshiProvider.kt
@@ -13,20 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.paykit.core.models.response
+package app.cash.paykit.core.network
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import app.cash.paykit.core.network.adapters.InstantAdapter
+import com.squareup.moshi.Moshi
 import kotlinx.datetime.Instant
 
-@JsonClass(generateAdapter = true)
-data class AuthFlowTriggers(
-  @Json(name = "mobile_url")
-  val mobileUrl: String,
-  @Json(name = "qr_code_image_url")
-  val qrCodeImageUrl: String,
-  @Json(name = "qr_code_svg_url")
-  val qrCodeSvgUrl: String,
-  @Json(name = "refreshes_at")
-  val refreshesAt: Instant,
-)
+internal object MoshiProvider {
+  fun provideDefault(): Moshi {
+    return Moshi.Builder().add(Instant::class.java, InstantAdapter()).build()
+  }
+}

--- a/core/src/main/java/app/cash/paykit/core/network/adapters/InstantAdapter.kt
+++ b/core/src/main/java/app/cash/paykit/core/network/adapters/InstantAdapter.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.network.adapters
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonReader.Token.NULL
+import com.squareup.moshi.JsonWriter
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
+
+internal class InstantAdapter : JsonAdapter<Instant>() {
+
+  override fun fromJson(reader: JsonReader): Instant? {
+    if (reader.peek() == NULL) {
+      return reader.nextNull<Instant>()
+    }
+    val timeRFC3339 = reader.nextString()
+    return timeRFC3339.toInstant()
+  }
+
+  override fun toJson(writer: JsonWriter, value: Instant?) {
+    if (value == null) {
+      writer.nullValue()
+    } else {
+      writer.value(value.toString())
+    }
+  }
+}

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
@@ -155,6 +155,7 @@ class CashAppPayStateTests {
     payKit.registerForStateUpdates(listener)
     val customerTopLevelResponse: NetworkResult.Success<CustomerTopLevelResponse> = mockk()
     every { customerTopLevelResponse.data.customerResponseData.status } returns STATUS_PENDING
+    every { customerTopLevelResponse.data.customerResponseData.authFlowTriggers } returns null
     every {
       networkManager.retrieveUpdatedRequestData(
         any(),


### PR DESCRIPTION
This PR handles the refresh logic for the auth flow token. In a nutshell, it works in the following way:

When the customer request is created, we capture the TTL by looking at the `refreshesAt` field within the `authFlowTriggers`. We then schedule a recurring refresh operation that runs at the cadence of `TTL - 10 seconds`. The refresh operation will be stopped if any of the following things happens:

 * The SDK is destroyed (right now captured by the function `unregisterFromStateUpdates`)
 * The SDK state mutate to anything other than `ReadyToAuthorize`
 * We've reached the expiration time for the `customer request`
 
If network errors occur, the refresh will continue to run indefinitely at the same cadence, until one of the criteria above is met. This is by design, as it might be an actual intended behavior depending on merchant implementation.

To support this PR, the following changes were made:
 * Made several of the internal dates `Instant`  for better date/time handling and brought in `kotlin-datetime` for better backwards support, that won't require Java 8 desuggaring 
 * Additionally, the thread for long-polling to get the grants was made more resilient by also being torn down during `unregisterFromStateUpdates`


### Verification 

Since the Threading model is currently all handled internally, and so are its side-effects, it isn't possible to easily unit test this implementation. I've relied on manual testing and logging to confirm the SDK is working as expected. We'll keep in mind this need for larger pieces of work going forward.