### PR TITLE
Add new Refreshing state

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/CashAppPayState.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayState.kt
@@ -60,6 +60,13 @@ sealed interface CashAppPayState {
   object Authorizing : CashAppPayState
 
   /**
+   * This state denotes that we're in the process of refreshing the existing customer request,
+   * in case the authorization has expired. This is typically an in-between between [Authorizing]
+   * and [PollingTransactionStatus].
+   */
+  object Refreshing : CashAppPayState
+
+  /**
    * This state denotes that we're actively polling for an authorization update. This state will
    * typically transition to either [Approved] or [Declined].
    */

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -28,6 +28,7 @@ import app.cash.paykit.core.CashAppPayState.Declined
 import app.cash.paykit.core.CashAppPayState.NotStarted
 import app.cash.paykit.core.CashAppPayState.PollingTransactionStatus
 import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
+import app.cash.paykit.core.CashAppPayState.Refreshing
 import app.cash.paykit.core.CashAppPayState.RetrievingExistingCustomerRequest
 import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.NetworkManager
@@ -295,6 +296,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
     return when (state) {
       is Approved -> "approved"
       Authorizing -> "redirect"
+      Refreshing -> "refreshing"
       CreatingCustomerRequest -> "create"
       Declined -> "declined"
       NotStarted -> "not_started"

--- a/core/src/main/java/app/cash/paykit/core/android/LogTag.kt
+++ b/core/src/main/java/app/cash/paykit/core/android/LogTag.kt
@@ -15,20 +15,4 @@
  */
 package app.cash.paykit.core.android
 
-import android.util.Log
-
-/**
- * This class is used to wrap a thread start operation in a way that allows for smooth degradation on exception, as well as convenient and consistent error handling.
- */
-fun Thread.safeStart(errorMessage: String?, onError: () -> Unit? = {}) {
-  try {
-    start()
-  } catch (e: IllegalThreadStateException) {
-    // This can happen if the thread is already started.
-    Log.e(LOG_TAG, errorMessage, e)
-    onError()
-  } catch (e: InterruptedException) {
-    Log.e(LOG_TAG, errorMessage, e)
-    onError()
-  }
-}
+const val LOG_TAG = "CashAppPay"

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -34,6 +34,7 @@ import app.cash.paykit.core.CashAppPayState.Declined
 import app.cash.paykit.core.CashAppPayState.NotStarted
 import app.cash.paykit.core.CashAppPayState.PollingTransactionStatus
 import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
+import app.cash.paykit.core.CashAppPayState.Refreshing
 import app.cash.paykit.core.CashAppPayState.RetrievingExistingCustomerRequest
 import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.NetworkManager
@@ -87,6 +88,7 @@ internal class CashAppCashAppPayImpl(
           customerResponseData,
         )
         Authorizing -> analyticsEventDispatcher.genericStateChanged(value, customerResponseData)
+        Refreshing -> analyticsEventDispatcher.genericStateChanged(value, customerResponseData)
         Declined -> analyticsEventDispatcher.genericStateChanged(value, customerResponseData)
         NotStarted -> analyticsEventDispatcher.genericStateChanged(value, customerResponseData)
         PollingTransactionStatus -> analyticsEventDispatcher.genericStateChanged(value, customerResponseData)
@@ -248,8 +250,6 @@ internal class CashAppCashAppPayImpl(
       return
     }
 
-    currentState = Authorizing
-
     if (customerData.isAuthTokenExpired()) {
       logInfo("Auth token expired when attempting to authenticate, refreshing before proceeding.")
       deferredAuthorizeCustomerRequest()
@@ -270,6 +270,8 @@ internal class CashAppCashAppPayImpl(
       logError("Error while interrupting previous thread. Exception: $e")
     }
 
+    currentState = Refreshing
+
     logInfo("Will refresh customer request before proceeding with authorization.")
     Thread {
       val networkResult = networkManager.retrieveUpdatedRequestData(
@@ -284,11 +286,11 @@ internal class CashAppCashAppPayImpl(
       logInfo("Refreshed customer request with SUCCESS")
       customerResponseData = (networkResult as Success).data.customerResponseData
 
-      if (currentState == Authorizing) {
+      if (currentState == Refreshing) {
         authorizeCustomerRequest(customerResponseData!!)
       }
     }.safeStart("Error while attempting to run deferred authorization.", onError = {
-      if (currentState == Authorizing) {
+      if (currentState == Refreshing) {
         currentState = CashAppPayExceptionState(CashAppPayNetworkException(CONNECTIVITY))
       }
     })
@@ -320,14 +322,13 @@ internal class CashAppCashAppPayImpl(
     // Replace internal state.
     customerResponseData = customerData
 
-    currentState = Authorizing
-
     if (customerData.isAuthTokenExpired()) {
       logInfo("Auth token expired when attempting to authenticate, refreshing before proceeding.")
       deferredAuthorizeCustomerRequest()
       return
     }
 
+    currentState = Authorizing
     try {
       ApplicationContextHolder.applicationContext.startActivity(intent)
     } catch (activityNotFoundException: ActivityNotFoundException) {

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppCashAppPayImpl.kt
@@ -40,6 +40,7 @@ import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.NetworkManager
 import app.cash.paykit.core.analytics.PayKitAnalyticsEventDispatcher
 import app.cash.paykit.core.android.ApplicationContextHolder
+import app.cash.paykit.core.android.LOG_TAG
 import app.cash.paykit.core.android.safeStart
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
 import app.cash.paykit.core.exceptions.CashAppPayNetworkErrorType.CONNECTIVITY
@@ -478,11 +479,11 @@ internal class CashAppCashAppPayImpl(
   }
 
   private fun logError(errorMessage: String) {
-    Log.e("CAP", errorMessage)
+    Log.e(LOG_TAG, errorMessage)
   }
 
   private fun logInfo(errorMessage: String) {
-    Log.i("CAP", errorMessage)
+    Log.i(LOG_TAG, errorMessage)
   }
 
   /**


### PR DESCRIPTION
Adding a new state called `Refreshing` to easily differentiate between a call to `authenticate` that promptly executes or another that has to defer and refresh the flow auth token.

This is beneficial for capturing analytics that distinguish both situations; while also giving partners more accurate information to adequately code their loading states.


## Verification
This video showcases a scenario where the polling refresh operation didn't succeed (device offline), and the authorize button is pressed right after internet connectivity is resumed and with auth-token being expired:

https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/7aa8c131-8c5d-4467-b555-66a8ad501ff8


Analytics for this new state being captured correctly:
![refreshing_state](https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/d746e613-d710-4792-9a4a-59068408d59a)

