### PR TITLE
Move thread management away from main class

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/utils/SingleThreadManager.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/SingleThreadManager.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+enum class ThreadPurpose {
+  REFRESH_AUTH_TOKEN,
+  CHECK_APPROVAL_STATUS,
+  DEFERRED_REFRESH,
+}
+
+/**
+ * A manager class that is responsible for creating and managing threads, and guarantee that
+ * each [ThreadPurpose] has only one thread at any given time.
+ */
+internal interface SingleThreadManager {
+  fun createThread(purpose: ThreadPurpose, runnable: Runnable): Thread
+
+  fun interruptThread(purpose: ThreadPurpose)
+
+  fun interruptAllThreads()
+}

--- a/core/src/main/java/app/cash/paykit/core/utils/SingleThreadManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/utils/SingleThreadManagerImpl.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paykit.core.utils
+
+import android.util.Log
+import app.cash.paykit.core.android.LOG_TAG
+
+internal class SingleThreadManagerImpl : SingleThreadManager {
+
+  private val threads: MutableMap<ThreadPurpose, Thread?> = mutableMapOf()
+
+  override fun createThread(purpose: ThreadPurpose, runnable: Runnable): Thread {
+    // Before creating a new thread of a given type, make sure the last one is interrupted.
+    interruptThread(purpose)
+
+    val thread = Thread(runnable, purpose.name)
+    threads[purpose] = thread
+    return thread
+  }
+
+  override fun interruptThread(purpose: ThreadPurpose) {
+    try {
+      threads[purpose]?.interrupt()
+    } catch (e: Exception) {
+      Log.e(LOG_TAG, "Failed to interrupt thread: ${purpose.name}", e)
+    } finally {
+      threads[purpose] = null
+    }
+  }
+
+  override fun interruptAllThreads() {
+    threads.keys.forEach { interruptThread(it) }
+  }
+}


### PR DESCRIPTION
This PR moves the thread handling complexity away from `CashAppCashAppPayImpl` into its own manager class.

This manager class is meant to guarantee that for each thread "purpose" (read, each type of job that's meant to be performed), only a single thread is executed at any given time. This is a behavior we want for all of our threads currently.

# Verification
This change also adds Thread naming for easier profiling. As can be seen here, Threads of the same type are finished successfully before a new one is started, so there are never 2 threads of the same "purpose" (kind) executing simultaneously.
<img width="1814" alt="Screenshot 2023-06-30 at 11 43 08 AM" src="https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/750d6a92-0633-4dd7-9457-6cbe28b7efdc">

I kept an eye on the total thread count while executing several tests to make sure the baseline remained consistent.
<img width="141" alt="Screenshot 2023-06-30 at 11 43 22 AM" src="https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/9a69fbd0-8756-4c31-a73f-653056b3a1fd">

