### PR TITLE
Simplify internal class names

### DIFF
--- a/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPay.kt
@@ -24,7 +24,7 @@ import app.cash.paykit.core.analytics.PayKitAnalyticsEventDispatcher
 import app.cash.paykit.core.analytics.PayKitAnalyticsEventDispatcherImpl
 import app.cash.paykit.core.android.ApplicationContextHolder
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import app.cash.paykit.core.impl.CashAppPayLifecycleObserverImpl
 import app.cash.paykit.core.impl.NetworkManagerImpl
 import app.cash.paykit.core.models.response.CustomerResponseData
@@ -185,7 +185,7 @@ object CashAppPayFactory {
       buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, ANALYTICS_PROD_ENVIRONMENT)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
-    return CashAppCashAppPayImpl(
+    return CashAppPayImpl(
       clientId = clientId,
       networkManager = networkManager,
       analyticsEventDispatcher = analyticsEventDispatcher,
@@ -212,7 +212,7 @@ object CashAppPayFactory {
       buildPayKitAnalyticsEventDispatcher(clientId, networkManager, analytics, ANALYTICS_SANDBOX_ENVIRONMENT)
     networkManager.analyticsEventDispatcher = analyticsEventDispatcher
 
-    return CashAppCashAppPayImpl(
+    return CashAppPayImpl(
       clientId = clientId,
       networkManager = networkManager,
       analyticsEventDispatcher = analyticsEventDispatcher,

--- a/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/analytics/PayKitAnalyticsEventDispatcherImpl.kt
@@ -33,7 +33,7 @@ import app.cash.paykit.core.CashAppPayState.RetrievingExistingCustomerRequest
 import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.NetworkManager
 import app.cash.paykit.core.analytics.AnalyticsEventStream2Event.Companion.ESEventType
-import app.cash.paykit.core.exceptions.CashAppCashAppPayApiNetworkException
+import app.cash.paykit.core.exceptions.CashAppPayApiNetworkException
 import app.cash.paykit.core.models.analytics.EventStream2Event
 import app.cash.paykit.core.models.analytics.payloads.AnalyticsBasePayload
 import app.cash.paykit.core.models.analytics.payloads.AnalyticsCustomerRequestPayload
@@ -178,7 +178,7 @@ internal class PayKitAnalyticsEventDispatcherImpl(
     var eventPayload =
       eventFromCustomerResponseData(customerResponseData).copy(action = stateToAnalyticsAction(payKitExceptionState))
 
-    eventPayload = if (payKitExceptionState.exception is CashAppCashAppPayApiNetworkException) {
+    eventPayload = if (payKitExceptionState.exception is CashAppPayApiNetworkException) {
       val apiError = payKitExceptionState.exception
       eventPayload.copy(
         errorCode = apiError.code,

--- a/core/src/main/java/app/cash/paykit/core/exceptions/CashAppPayApiNetworkException.kt
+++ b/core/src/main/java/app/cash/paykit/core/exceptions/CashAppPayApiNetworkException.kt
@@ -20,7 +20,7 @@ import app.cash.paykit.core.exceptions.CashAppPayNetworkErrorType.API
 /**
  * This exception encapsulates all of the metadata provided by an API error.
  */
-data class CashAppCashAppPayApiNetworkException(
+data class CashAppPayApiNetworkException(
   val category: String,
   val code: String,
   val detail: String?,

--- a/core/src/main/java/app/cash/paykit/core/impl/CashAppPayImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/CashAppPayImpl.kt
@@ -66,7 +66,7 @@ import kotlin.time.Duration.Companion.seconds
  * @param clientId Client Identifier that should be provided by Cash PayKit integration.
  * @param useSandboxEnvironment Specify what development environment should be used.
  */
-internal class CashAppCashAppPayImpl(
+internal class CashAppPayImpl(
   private val clientId: String,
   private val networkManager: NetworkManager,
   private val analyticsEventDispatcher: PayKitAnalyticsEventDispatcher,

--- a/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
+++ b/core/src/main/java/app/cash/paykit/core/impl/NetworkManagerImpl.kt
@@ -17,7 +17,7 @@ package app.cash.paykit.core.impl
 
 import app.cash.paykit.core.NetworkManager
 import app.cash.paykit.core.analytics.PayKitAnalyticsEventDispatcher
-import app.cash.paykit.core.exceptions.CashAppCashAppPayApiNetworkException
+import app.cash.paykit.core.exceptions.CashAppPayApiNetworkException
 import app.cash.paykit.core.exceptions.CashAppPayConnectivityNetworkException
 import app.cash.paykit.core.impl.RequestType.GET
 import app.cash.paykit.core.impl.RequestType.PATCH
@@ -249,7 +249,7 @@ internal class NetworkManagerImpl(
 
               is Success -> {
                 val apiError = apiErrorResponse.data.apiErrors.first()
-                val apiException = CashAppCashAppPayApiNetworkException(
+                val apiException = CashAppPayApiNetworkException(
                   apiError.category,
                   apiError.code,
                   apiError.detail,

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayAuthorizeTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayAuthorizeTests.kt
@@ -17,7 +17,7 @@ package app.cash.paykit.core
 
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
 import app.cash.paykit.core.fakes.FakeData
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import app.cash.paykit.core.models.response.CustomerResponseData
 import io.mockk.every
 import io.mockk.mockk
@@ -73,7 +73,7 @@ class CashAppPayAuthorizeTests {
   }
 
   private fun createPayKit() =
-    CashAppCashAppPayImpl(
+    CashAppPayImpl(
       clientId = FakeData.CLIENT_ID,
       networkManager = mockk(),
       payKitLifecycleListener = mockk(relaxed = true),

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayExceptionsTests.kt
@@ -17,7 +17,7 @@ package app.cash.paykit.core
 
 import app.cash.paykit.core.exceptions.CashAppPayIntegrationException
 import app.cash.paykit.core.fakes.FakeData
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import app.cash.paykit.core.models.common.NetworkResult
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -63,7 +63,7 @@ class CashAppPayExceptionsTests {
   }
 
   private fun createPayKit(useSandboxEnvironment: Boolean) =
-    CashAppCashAppPayImpl(
+    CashAppPayImpl(
       clientId = FakeData.CLIENT_ID,
       networkManager = networkManager,
       payKitLifecycleListener = mockk(relaxed = true),

--- a/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/CashAppPayStateTests.kt
@@ -28,7 +28,7 @@ import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
 import app.cash.paykit.core.CashAppPayState.UpdatingCustomerRequest
 import app.cash.paykit.core.android.ApplicationContextHolder
 import app.cash.paykit.core.fakes.FakeData
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import app.cash.paykit.core.impl.CashAppPayLifecycleListener
 import app.cash.paykit.core.models.common.NetworkResult
 import app.cash.paykit.core.models.response.CustomerResponseData
@@ -285,7 +285,7 @@ class CashAppPayStateTests {
     initialState: CashAppPayState = NotStarted,
     initialCustomerResponseData: CustomerResponseData? = null,
   ) =
-    CashAppCashAppPayImpl(
+    CashAppPayImpl(
       clientId = FakeData.CLIENT_ID,
       networkManager = networkManager,
       payKitLifecycleListener = mockLifecycleListener,

--- a/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkErrorTests.kt
@@ -16,10 +16,10 @@
 package app.cash.paykit.core
 
 import app.cash.paykit.core.CashAppPayState.CashAppPayExceptionState
-import app.cash.paykit.core.exceptions.CashAppCashAppPayApiNetworkException
+import app.cash.paykit.core.exceptions.CashAppPayApiNetworkException
 import app.cash.paykit.core.exceptions.CashAppPayConnectivityNetworkException
 import app.cash.paykit.core.fakes.FakeData
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import app.cash.paykit.core.impl.NetworkManagerImpl
 import app.cash.paykit.core.network.RetryManagerOptions
 import com.google.common.truth.Truth.assertThat
@@ -107,11 +107,11 @@ class NetworkErrorTests {
     // Verify that all the appropriate exception wrapping has occurred for a 400 error.
     assertThat(mockListener.state).isInstanceOf(CashAppPayExceptionState::class.java)
     assertThat((mockListener.state as CashAppPayExceptionState).exception).isInstanceOf(
-      CashAppCashAppPayApiNetworkException::class.java,
+      CashAppPayApiNetworkException::class.java,
     )
 
     // Verify that all the API error details have been deserialized correctly.
-    val apiError = (mockListener.state as CashAppPayExceptionState).exception as CashAppCashAppPayApiNetworkException
+    val apiError = (mockListener.state as CashAppPayExceptionState).exception as CashAppPayApiNetworkException
     assertThat(apiError.code).isEqualTo("MISSING_REQUIRED_PARAMETER")
     assertThat(apiError.category).isEqualTo("INVALID_REQUEST_ERROR")
     assertThat(apiError.field_value).isEqualTo("request.action.amount")
@@ -235,7 +235,7 @@ class NetworkErrorTests {
   }
 
   private fun createPayKit(networkManager: NetworkManager) =
-    CashAppCashAppPayImpl(
+    CashAppPayImpl(
       clientId = FakeData.CLIENT_ID,
       networkManager = networkManager,
       payKitLifecycleListener = mockk(relaxed = true),

--- a/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
+++ b/core/src/test/java/app/cash/paykit/core/NetworkRetryTests.kt
@@ -20,7 +20,7 @@ import app.cash.paykit.core.CashAppPayState.ReadyToAuthorize
 import app.cash.paykit.core.NetworkErrorTests.MockListener
 import app.cash.paykit.core.exceptions.CashAppPayConnectivityNetworkException
 import app.cash.paykit.core.fakes.FakeData
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import app.cash.paykit.core.impl.NetworkManagerImpl
 import app.cash.paykit.core.network.RetryManagerOptions
 import com.google.common.truth.Truth.assertThat
@@ -188,7 +188,7 @@ class NetworkRetryTests {
   }
 
   private fun createPayKit(networkManager: NetworkManager) =
-    CashAppCashAppPayImpl(
+    CashAppPayImpl(
       clientId = FakeData.CLIENT_ID,
       networkManager = networkManager,
       payKitLifecycleListener = mockk(relaxed = true),

--- a/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
+++ b/core/src/testRelease/java/app/cash/paykit/core/CashAppPayProdExceptionsTests.kt
@@ -16,7 +16,7 @@
 package app.cash.paykit.core
 
 import app.cash.paykit.core.fakes.FakeData
-import app.cash.paykit.core.impl.CashAppCashAppPayImpl
+import app.cash.paykit.core.impl.CashAppPayImpl
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
@@ -42,7 +42,7 @@ class CashAppPayProdExceptionsTests {
   }
 
   private fun createPayKit(useSandboxEnvironment: Boolean) =
-    CashAppCashAppPayImpl(
+    CashAppPayImpl(
       clientId = FakeData.CLIENT_ID,
       networkManager = networkManager,
       payKitLifecycleListener = mockk(relaxed = true),


### PR DESCRIPTION
When we were approaching public release, we renamed a few classes from `paykit` to `cashapppay`. During this renaming, some of the internal class names became unnecessarily verbose but I didn't notice that until later.

This PR addresses that, by making these classes names concise yet compliant with what we originally intended.

Example of renaming: `CashAppCashAppPayImpl` > `CashAppPayImpl`