### PR TITLE
Make Initializer open to modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.3.0
 
+Class `CashAppPayInitializer` was made open, so that androidx.startup can be manually overridden.
+
 This version contains change to the bundled Cash App Pay button.
 Previously, `light` and `dark` variants of the button were made possible by using 2 different
 views, respectively `CashAppPayButtonLight` an `CashAppPayButtonDark`. As of this version, the

--- a/core/src/main/java/app/cash/paykit/core/CashAppPayInitializer.kt
+++ b/core/src/main/java/app/cash/paykit/core/CashAppPayInitializer.kt
@@ -20,10 +20,10 @@ import androidx.annotation.Keep
 import androidx.startup.Initializer
 import app.cash.paykit.core.android.ApplicationContextHolder
 
-internal interface CashAppPayInitializerStub
+interface CashAppPayInitializerStub
 
 @Keep
-internal class CashAppPayInitializer : Initializer<CashAppPayInitializerStub> {
+class CashAppPayInitializer : Initializer<CashAppPayInitializerStub> {
   override fun create(context: Context): CashAppPayInitializerStub {
     ApplicationContextHolder.init(context.applicationContext)
     return object : CashAppPayInitializerStub {}


### PR DESCRIPTION
## What are you trying to accomplish?

Allows for partners to override the auto SDK initialization that happens as soon as the app starts, for partners who want fine tuned control over manually initializing the SDK at a later stage.

## How did you accomplish this?

This work had already been done, but it was never merged in : https://github.com/cashapp/cash-app-pay-android-sdk/pull/105

Given the codebase has changed dramatically since then, it was easier to replicate the changes and open a new PR instead.


## Verification:

Manually verified that the SDK runs correctly. Also, followed the instructions to override initialization and it works as expected.