### PR TITLE
Add minify rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 2.3.0
+# UPCOMING - 2.3.0
 
-Class `CashAppPayInitializer` was made open, so that androidx.startup can be manually overridden.
-
-This version contains change to the bundled Cash App Pay button.
+ - The class `CashAppPayInitializer` was made open, so that androidx.startup can be manually overridden.
+ - This version bundles fixes for minify enabled builds.
+ - This version contains change to the bundled Cash App Pay button.
 Previously, `light` and `dark` variants of the button were made possible by using 2 different
 views, respectively `CashAppPayButtonLight` an `CashAppPayButtonDark`. As of this version, the
 there will only be a single `CashAppPayButton` view, which has been updated to support both variants.

--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,11 @@ subprojects { subproject ->
   }
 }
 
-def NEXT_VERSION = "2.3.2-SNAPSHOT"
+def NEXT_VERSION = "2.3.3-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '2.3.1-SNAPSHOT'
+  version = '2.3.2-SNAPSHOT'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,11 @@ subprojects { subproject ->
   }
 }
 
-def NEXT_VERSION = "2.3.1-SNAPSHOT"
+def NEXT_VERSION = "2.3.2-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '2.3.0-SNAPSHOT'
+  version = '2.3.1-SNAPSHOT'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -44,6 +44,36 @@
 # However, since in this case they will not be used, we can disable these warnings
 -dontwarn kotlinx.serialization.internal.ClassValueReferences
 
+# Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
+# If you have any, replace classes with those containing named companion objects.
+-keepattributes InnerClasses # Needed for `getDeclaredClasses`.
+
+-if @kotlinx.serialization.Serializable class
+kotlinx.datetime.Instant$Companion, # <-- List serializable classes with named companions.
+kotlinx.datetime.Instant$Companion$serializer
+{
+    static **$* *;
+}
+-keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
+    static <1>$$serializer INSTANCE;
+}
+
+# Keep both serializer and serializable classes to save the attribute InnerClasses
+-keepclasseswithmembers, allowshrinking, allowobfuscation, allowaccessmodification class
+kotlinx.datetime.Instant$Companion, # <-- List serializable classes with named companions.
+kotlinx.datetime.Instant$Companion$serializer
+{
+    *;
+}
+
+-dontwarn kotlinx.serialization.KSerializer
+-dontwarn kotlinx.serialization.Serializable
+-dontwarn kotlinx.serialization.descriptors.PrimitiveKind$STRING
+-dontwarn kotlinx.serialization.descriptors.PrimitiveKind
+-dontwarn kotlinx.serialization.descriptors.SerialDescriptor
+-dontwarn kotlinx.serialization.descriptors.SerialDescriptorsKt
+-dontwarn kotlinx.serialization.internal.AbstractPolymorphicSerializer
+
 
 # OkHttp related. Can be removed after OkHttp is updated.
 -dontwarn org.bouncycastle.jsse.BCSSLParameters

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -1,0 +1,57 @@
+# Keep enums within the project.
+-keep enum app.cash.paykit.core.models.response.GrantType { *; }
+-keep enum app.cash.paykit.core.models.sdk.CashAppPayCurrency { *; }
+-keep enum app.cash.paykit.core.impl.RequestType { *; }
+-keep enum app.cash.paykit.core.utils.ThreadPurpose { *; }
+
+
+# Rules for Kotlin Serializer - a transitive dependency of KotlinX Datetime.
+# Can probably be removed after datetime is updated.
+
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+# Don't print notes about potential mistakes or omissions in the configuration for kotlinx-serialization classes
+# See also https://github.com/Kotlin/kotlinx.serialization/issues/1900
+-dontnote kotlinx.serialization.**
+
+# Serialization core uses `java.lang.ClassValue` for caching inside these specified classes.
+# If there is no `java.lang.ClassValue` (for example, in Android), then R8/ProGuard will print a warning.
+# However, since in this case they will not be used, we can disable these warnings
+-dontwarn kotlinx.serialization.internal.ClassValueReferences
+
+
+# OkHttp related. Can be removed after OkHttp is updated.
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE


### PR DESCRIPTION
## Jira Ticket
[CASHPAY-2993](https://block.atlassian.net/browse/CASHPAY-2993)

## What are you trying to accomplish?

On the latest Android SDK version, 2.2.0, if minify is enabled the compilation fails with an error regarding Kotlin’s Serialization. This happens because a transitive dependency on serialization is happening trough `KotlinX datetime` library .

## How did you accomplish this?

To investigate, I made the build target equal to `release`, and enabled `minify`. I tested on both the SDK Dev App and on our Sample App.
Newer versions of KotlinX serialize bundle the R8 proguard rules: https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.5.0-RC

Kotlin's datetime is still using an older version, but we could force the transitive dependency to be updated by including a direct dependency with the version required. However this version depends on Kotlin `1.8.10`, which would force our project to update its Kotlin version, and we ideally don't want that simply to fix this issue. So instead I've fined tuned the proguard rules necessary, and bundled them with our SDK via the `consumer-rules.pro` file.

In addition to this issue with minify, separate issues also pertaining to `minify` with the `Grant` enum and `okhttp` dependencies were identified. OkHttp version `5.Y.X` will bundle fixes for this, but for now it is still under development.

## Visual:

Here's a video of the Dev App built with `minify enabled` . The console doesn't display the whole contents of the payload because of the obfuscation of the classes, which is expected (serves as a proof that the app is running after minify).

https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/2276bc25-aa83-4f44-8b8b-150d47cde933

