### PR TITLE
Update Android target version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Static Analysis
         run: ./gradlew lint spotlessCheck

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Publish Artifacts
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.0 - UPCOMING
+
+ - Update Android target SDK version to API 33 
+
 # 2.3.0
 
  - The class `CashAppPayInitializer` was made open, so that androidx.startup can be manually overridden.

--- a/analytics-core/build.gradle
+++ b/analytics-core/build.gradle
@@ -39,6 +39,10 @@ android {
     warningsAsErrors true
     baseline file("lint-baseline.xml")
   }
+
+  buildFeatures {
+    buildConfig = true
+  }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
 
     versions = [
         'minSdk': 21,
-        'compileSdk': 31,
-        'targetSdk': 31,
+        'compileSdk': 33,
+        'targetSdk': 33,
     ]
   }
 }
@@ -52,11 +52,11 @@ subprojects { subproject ->
   }
 }
 
-def NEXT_VERSION = "2.3.4-SNAPSHOT"
+def NEXT_VERSION = "2.4.1-SNAPSHOT"
 
 allprojects {
   group = 'app.cash.paykit'
-  version = '2.3.0'
+  version = '2.4.0-SNAPSHOT'
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ buildscript {
 }
 
 plugins {
-  id 'com.android.application' version '7.4.2' apply false
-  id 'com.android.library' version '7.4.2' apply false
+  id 'com.android.application' version '8.1.2' apply false
+  id 'com.android.library' version '8.1.2' apply false
   id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
   id "com.diffplug.spotless" version "6.20.0"
   id "com.vanniktech.maven.publish.base" version "0.25.1"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 task sourceJar(type: Jar) {
   from android.sourceSets.main.java.srcDirs
-  classifier "sources"
+  archiveClassifier.set('sources')
 }
 
 android {
@@ -56,6 +56,10 @@ android {
       returnDefaultValues = true
       includeAndroidResources = true
     }
+  }
+
+  buildFeatures {
+    buildConfig = true
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 09 13:50:05 PST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -11,7 +11,7 @@ com.android.tools.analytics.AnalyticsSettings.optedIn = false
 
 android {
   namespace = "app.cash.paykit.logging"
-  compileSdk = 31
+  compileSdk = 33
 
   defaultConfig {
     minSdk = 21


### PR DESCRIPTION
## Jira Ticket

Update Android compile version to `API 33`, which is now the minimum required for Google Play Store app updates.

## What are you trying to accomplish?

* Increase the `compile` and `target` versions, for various SDK modules

## Steps to manually test this change:

Ran unit tests and manual verification on sandbox.