### PR TITLE
Update AGP to 8.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Static Analysis
         run: ./gradlew lint spotlessCheck

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Publish Artifacts
         run: |

--- a/analytics-core/build.gradle
+++ b/analytics-core/build.gradle
@@ -39,6 +39,10 @@ android {
     warningsAsErrors true
     baseline file("lint-baseline.xml")
   }
+
+  buildFeatures {
+    buildConfig = true
+  }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ buildscript {
 }
 
 plugins {
-  id 'com.android.application' version '7.4.2' apply false
-  id 'com.android.library' version '7.4.2' apply false
+  id 'com.android.application' version '8.1.2' apply false
+  id 'com.android.library' version '8.1.2' apply false
   id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
   id "com.diffplug.spotless" version "6.20.0"
   id "com.vanniktech.maven.publish.base" version "0.25.1"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 task sourceJar(type: Jar) {
   from android.sourceSets.main.java.srcDirs
-  classifier "sources"
+  archiveClassifier.set('sources')
 }
 
 android {
@@ -56,6 +56,10 @@ android {
       returnDefaultValues = true
       includeAndroidResources = true
     }
+  }
+
+  buildFeatures {
+    buildConfig = true
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 09 13:50:05 PST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update AGP to the latest stable version.

## What are you trying to accomplish?

Update AGP to the latest stable version, `8.1.2`.

## How did you accomplish this?

 - Update version numbers
 - Update `sourceJar` Gradle task, to newer definition
 - Minor changes to support `buildconfig`
 - Update CI Java version to `17`

## Visual:

Happy path of the app, working as expected.


https://github.com/cashapp/cash-app-pay-android-sdk/assets/416941/facac958-0ef5-447e-8de3-bb6b68b03945

