### PR TITLE
Migrate to Sonatype Central Portal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,7 @@ jobs:
           ./gradlew clean publish --stacktrace
 
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,9 @@ buildscript {
 plugins {
   id 'com.android.application' version '8.8.1' apply false
   id 'com.android.library' version '8.8.1' apply false
-  id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
+  id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
   id "com.diffplug.spotless" version "6.20.0"
-  id "com.vanniktech.maven.publish.base" version "0.25.1"
+  id "com.vanniktech.maven.publish.base" version "0.28.0"
 }
 
 subprojects { subproject ->
@@ -61,7 +61,7 @@ allprojects {
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     mavenPublishing {
-      publishToMavenCentral(SonatypeHost.DEFAULT, true)
+      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
       signAllPublications()
       pom {
         description.set("Cash App Pay SDK")


### PR DESCRIPTION
# DO NOT MERGE!!!

See (internally) http://go/central-portal-migration-app-cash for context.

Note: This PR build may not pass. Normally I would have opened an issue with instructions, but issues are disabled. Please consider updating your Kotlin and publish plugin versions separately to versions equal to or newer than those in this PR. Once migration occurs, you will not be able to publish without updating to these versions or, preferably, even newer ones.